### PR TITLE
chore: Downgrade to React 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.2.0",
-        "@testing-library/react": "^14.1.2",
+        "@testing-library/react": "^12.1.5",
         "@types/jest": "^29.5.11",
         "@types/lodash": "^4.14.202",
         "@types/prismjs": "^1.26.3",
@@ -40,8 +40,8 @@
         "live-server": "^1.2.2",
         "markdown-to-jsx": "^7.3.2",
         "prettier": "2.8.3",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": ">= 17.0.2",
+        "react-dom": ">= 17.0.2",
         "react-icons": "^5.0.1",
         "react-jsx-parser": "^1.29.0",
         "react-router-dom": "^6.8.2",
@@ -51,8 +51,8 @@
       },
       "peerDependencies": {
         "axios": "^1.6.7",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": ">= 17.0.2",
+        "react-dom": ">= 17.0.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1856,9 +1856,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
-      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
+      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -1871,7 +1871,7 @@
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@testing-library/dom/node_modules/aria-query": {
@@ -1947,21 +1947,41 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
-      "integrity": "sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
+      "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^9.0.0",
-        "@types/react-dom": "^18.0.0"
+        "@testing-library/dom": "^8.0.0",
+        "@types/react-dom": "<18.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "<18.0.0",
+        "react-dom": "<18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/@types/react": {
+      "version": "17.0.75",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.75.tgz",
+      "integrity": "sha512-MSA+NzEzXnQKrqpO63CYqNstFjsESgvJAdAyyJ1n6ZQq/GLgf6nOfIKwk+Twuz0L1N6xPe+qz5xRCJrbhMaLsw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/@types/react-dom": {
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
+      "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "^17"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -9361,11 +9381,12 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -9383,16 +9404,17 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-focus-lock": {
@@ -10025,12 +10047,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "dev": true,
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.2.0",
-    "@testing-library/react": "^14.1.2",
+    "@testing-library/react": "^12.1.5",
     "@types/jest": "^29.5.11",
     "@types/lodash": "^4.14.202",
     "@types/prismjs": "^1.26.3",
@@ -62,8 +62,8 @@
     "live-server": "^1.2.2",
     "markdown-to-jsx": "^7.3.2",
     "prettier": "2.8.3",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": ">= 17.0.2",
+    "react-dom": ">= 17.0.2",
     "react-icons": "^5.0.1",
     "react-jsx-parser": "^1.29.0",
     "react-router-dom": "^6.8.2",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "axios": "^1.6.7",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": ">= 17.0.2",
+    "react-dom": ">= 17.0.2"
   }
 }


### PR DESCRIPTION
## CONTEXT
In order to support a wider spectrum of applications, we should downgrade to React 17

## CHANGES
- Downgrade react to 17.0.2
- Downgrade react-dom to 17.0.2
- Downgrade RTL to 12.1.5