### PR TITLE
fix: prevent vertical overflow on smaller screens

### DIFF
--- a/src/components/chatView.scss
+++ b/src/components/chatView.scss
@@ -199,8 +199,8 @@ $chatbotPosition: $sizeS;
   .vrcbChatbotWrapper {
     right: 0;
     bottom: 0;
-    height: 100vh;
-    max-height: 100vh;
+    height: 100%;
+    max-height: 100%;
     border-radius: 0;
     border: none;
     border-left: 1px solid $borderColor;


### PR DESCRIPTION
## CONTEXT 

On mobile devices, the height of the chat window overflows. This needs to be fixed to avoid clipping the chat messages.

## CHANGES
- change height from 100vh to 100% (I'm not an expert on vh, but read about inconsistencies in what 100vh depending on DOM structure, zoom level, and surrounding CSS, etc, so I just changed to 100% since we want it to take the full screen height anyway)

## SCREENSHOTS

### BEFORE
<img src="https://github.com/vectara/react-chatbot/assets/1464245/f7302113-5fcf-4a7d-863d-f6c9533d730c" height="400"></img>

### AFTER
<img src="https://github.com/vectara/react-chatbot/assets/1464245/25d24d7b-f89b-44e2-8495-d9b41c8f59d3" height="400"></img>



