### PR TITLE
fix: Temporarily support English only

### DIFF
--- a/src/useChat.ts
+++ b/src/useChat.ts
@@ -13,7 +13,7 @@ export const useChat = (customerId: string, corpusIds: string[], apiKey: string)
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [conversationId, setConversationId] = useState<string | undefined>();
   const [error, setError] = useState<boolean>(false);
-  const getLanguage = (languageValue?: string): SummaryLanguage => (languageValue ?? "auto") as SummaryLanguage;
+  const getLanguage = (languageValue?: string): SummaryLanguage => (languageValue ?? "eng") as SummaryLanguage;
 
   const sendMessage = async ({ query, isRetry = false }: { query: string; isRetry?: boolean }) => {
     if (isLoading) return;


### PR DESCRIPTION
## CONTEXT
We've had cases in chat where the platform has tried to auto-detect the language and come up with something like this. We need to default to English for now so that responses are not unnecessarily translated:
![image](https://github.com/vectara/react-chatbot/assets/1464245/3bbbaae0-7116-4429-8d48-d8ac03c0f16c)

## CHANGES
- default getLanguage language value to "eng" instead of "auto"
  - This allows us to prefer English by default but also keep the utility function for when we want to support language as an option.

## SCREENSHOTS

### BEFORE 
<img src="https://github.com/vectara/react-chatbot/assets/1464245/3bbbaae0-7116-4429-8d48-d8ac03c0f16c" height=400>

### AFTER
<img src="https://github.com/vectara/react-chatbot/assets/1464245/8c448ea5-5fa1-4830-8f05-8b9b441b81e6" height=400>

