### PR TITLE
fix: pass title into closed chatbot button

### DIFF
--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -189,7 +189,7 @@ const App = () => {
               corpusIds={corpusIds.length === 0 ? DEFAULT_CORPUS_IDS : corpusIds}
               customerId={customerId === "" ? DEFAULT_CUSTOMER_ID : customerId}
               apiKey={apiKey === "" ? DEFAULT_API_KEY : apiKey}
-              title={title}
+              title={title === "" ? undefined : title}
               placeholder={placeholder}
               inputSize={inputSize}
               emptyStateDisplay={emptyStateJsx === "" ? undefined : <CustomEmptyStateDisplay />}

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -173,7 +173,7 @@ export const ChatView = ({
     </div>
   ) : (
     <button className="vrcbChatbotButton" onClick={() => setIsOpen(true)} style={{ zIndex }}>
-      Chat with your AI assistant
+      {title}
     </button>
   );
 };


### PR DESCRIPTION
## CONTEXT
The closed chatbot button currently defaults to "Chat with your AI assistant". This does not reflect the title of the chatbot once the chat window is opened.

## CHANGES
- Pass the chatbot title prop to the text of the closed chatbot button
- Update the docs to show the default "My Chatbot" text if no custom text is supplied by the user

## SCREENSHOTS

### BEFORE
#### Closed Button
<img width="232" alt="Screenshot 2024-02-28 at 11 12 45 AM" src="https://github.com/vectara/react-chatbot/assets/1464245/defdc5c0-c2a6-4d28-ab97-644bd1910a80">

#### Window Title
<img width="616" alt="Screenshot 2024-02-28 at 11 12 48 AM" src="https://github.com/vectara/react-chatbot/assets/1464245/c9f823e6-6026-48b8-b75d-b6b921adc211">

### AFTER
#### Closed Button
<img width="189" alt="Screenshot 2024-02-28 at 11 11 36 AM" src="https://github.com/vectara/react-chatbot/assets/1464245/0a341c30-ddda-4373-98cc-1b197378de46">

#### Window Title
<img width="623" alt="Screenshot 2024-02-28 at 11 11 45 AM" src="https://github.com/vectara/react-chatbot/assets/1464245/b41ccc98-d66c-4644-9651-12976ad96611">




