### PR TITLE
fix: add markdown-to-jsx as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "peerDependencies": {
     "axios": "^1.6.7",
+    "markdown-to-jsx": "^7.3.2",
     "react": ">= 17.0.2",
     "react-dom": ">= 17.0.2"
   }


### PR DESCRIPTION
## CONTEXT 
I missed adding markdown-to-jsx as a  peer dependency. This caused issues during integration testing.

## CHANGES
- Update package.json