### PR TITLE
chore: Fix bugs - external CSS leaks, sending empty queries, CSSStylesheet constructor error on mobile

### DIFF
--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -129,7 +129,7 @@ const App = () => {
     return (
       // @ts-ignore
       <JsxParser jsx={emptyStateJsx} />
-    ) as ReactNode;
+    );
   }, [emptyStateJsx]);
 
   return (

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -110,12 +110,13 @@ export const ChatView = ({
   }
 
   const hasContent = isLoading || messageHistory.length > 0;
+  const isRequestDisabled = isLoading || query.trim().length === 0;
 
-  const onSendQuery = useCallback(() => {
-    if (isLoading || query.trim().length === 0) return;
+  const onSendQuery = () => {
+    if (isRequestDisabled) return;
     sendMessage({ query });
     setQuery("");
-  }, [setQuery, sendMessage, isLoading]);
+  };
 
   useEffect(updateScrollPosition, [isLoading, messageHistory]);
 
@@ -166,7 +167,7 @@ export const ChatView = ({
             buttonLabel="Send"
             query={query}
             setQuery={setQuery}
-            isButtonDisabled={isLoading || query.trim().length === 0}
+            isButtonDisabled={isRequestDisabled}
             onSubmit={onSendQuery}
             size={inputSizeToQueryInputSize[inputSize]}
           />

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -112,7 +112,7 @@ export const ChatView = ({
   const hasContent = isLoading || messageHistory.length > 0;
 
   const onSendQuery = useCallback(() => {
-    if (isLoading) return;
+    if (isLoading || query.trim().length === 0) return;
     sendMessage({ query });
     setQuery("");
   }, [setQuery, sendMessage, isLoading]);
@@ -166,7 +166,7 @@ export const ChatView = ({
             buttonLabel="Send"
             query={query}
             setQuery={setQuery}
-            isDisabled={isLoading}
+            isButtonDisabled={isLoading || query.trim().length === 0}
             onSubmit={onSendQuery}
             size={inputSizeToQueryInputSize[inputSize]}
           />

--- a/src/components/QueryInput.tsx
+++ b/src/components/QueryInput.tsx
@@ -7,14 +7,14 @@ type Props = {
   onSubmit: () => void;
   placeholder: string;
   buttonLabel: string;
-  isDisabled?: boolean;
+  isButtonDisabled?: boolean;
   size: "l" | "m";
 };
 
 /**
  * The chat window input field and submit button.
  */
-export const QueryInput = ({ query, setQuery, onSubmit, placeholder, buttonLabel, isDisabled, size }: Props) => {
+export const QueryInput = ({ query, setQuery, onSubmit, placeholder, buttonLabel, isButtonDisabled, size }: Props) => {
   const onSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
   };
@@ -39,7 +39,7 @@ export const QueryInput = ({ query, setQuery, onSubmit, placeholder, buttonLabel
       </VuiFlexItem>
 
       <VuiFlexItem>
-        <VuiButtonPrimary color="primary" size={size} onClick={() => onSubmit()} isDisabled={isDisabled}>
+        <VuiButtonPrimary color="primary" size={size} onClick={() => onSubmit()} isDisabled={isButtonDisabled}>
           {buttonLabel}
         </VuiButtonPrimary>
       </VuiFlexItem>

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,9 @@
+:host {
+  all: initial;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
 @import "./components/chatView.scss";
 @import "./components/loader.scss";
 @import "./vui/_index.scss";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -97,9 +97,20 @@ class ReactChatbotWebComponent extends HTMLElement {
   constructor() {
     super();
     this.sr = this.attachShadow({ mode: "open" });
-    this.sheet = new CSSStyleSheet();
-    this.sheet.replaceSync(cssText);
-    this.sr.adoptedStyleSheets = [this.sheet];
+
+    // If the CSSStyleSheet constructor isn't supported, default to creating a style element.
+    // We prefer the CSSStyleSheet approach as it's a recommended way to style web components, and growing in support:
+    // https://webcomponents.guide/learn/components/styling/
+    try {
+      this.sheet = new CSSStyleSheet();
+      this.sheet.replaceSync(cssText);
+      this.sr.adoptedStyleSheets = [this.sheet];
+    } catch {
+      const styleElement = document.createElement("style");
+      styleElement.innerText = cssText;
+      this.sr.appendChild(styleElement);
+    }
+
     this.mountPoint = document.createElement("div");
     this.sr.appendChild(this.mountPoint);
   }


### PR DESCRIPTION
## CONTEXT
We have a number of bugs that need to be addressed:
- external CSS leaking into the shadow DOM of the react-chatbot web component
- users able to send a query even if the text input field is empty
- the chatbot component breaking on mobile browsers since mounting it inside a web component


## CHANGES
- Introduce `:host` selector styling to reset all styles in the web component's shadow host
- Short-circuit text input submit handler if the trimmed query is of length 0
- Rename QueryInput `isDisabled` prop to `isButtonDisabled` since only the button uses it i
- Set QueryInput `isButtonDisabled` prop to true if waiting for a chat response or trimmed query is of length 0
- When constructing web component styles, fall back to style element if CSSStylesheet constructor is not supported