### PR TITLE
chore: fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "name": "Vectara, Inc.",
     "url": "https://www.vectara.com"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "homepage": "https://vectara.github.io/react-chatbot/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## CONTEXT
The package.json license field should match the actual license file.

## CHANGES
- Update the license field in package.json to "Apache-2.0"