### PR TITLE
feat: Add reset conversation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ The values returned by the hook can be passed on to your custom components as pr
 
 This is used to send a message to the chat API. Send `true` for the optional `isRetry` flag to if this is retrying a previously failed message. This allows the internal logic to correctly link the next successful answer to the failed query.
 
-##### resetConversation: `() => void;`
+##### startNewConversation: `() => void;`
 
-This is used to reset the chat. Message history and topics discussed previosuly are restored to their initial state.
+This is used to reset the conversational context of the chat. The message history will be cleared and the chatbot will "forget" everything that's been discussed.
 
 ##### messageHistory: `ChatTurn[]`
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ import { useChat } from "@vectara/react-chatbot/lib";
 
 /* snip */
 
-const { sendMessage, messageHistory, isLoading, hasError } = useChat(
+const { sendMessage, resetConversation, messageHistory, isLoading, hasError } = useChat(
   "CUSTOMER_ID",
   ["CORPUS_ID_1", "CORPUS_ID_2", "CORPUS_ID_N"],
   "API_KEY"
@@ -138,6 +138,10 @@ The values returned by the hook can be passed on to your custom components as pr
 ##### sendMessage: `async ({ query: string; isRetry?: boolean }) => void;`
 
 This is used to send a message to the chat API. Send `true` for the optional `isRetry` flag to if this is retrying a previously failed message. This allows the internal logic to correctly link the next successful answer to the failed query.
+
+##### resetConversation: `() => void;`
+
+This is used to reset the chat. Message history and topics discussed previosuly are restored to their initial state.
 
 ##### messageHistory: `ChatTurn[]`
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ import { useChat } from "@vectara/react-chatbot/lib";
 
 /* snip */
 
-const { sendMessage, resetConversation, messageHistory, isLoading, hasError } = useChat(
+const { sendMessage, startNewConversation, messageHistory, isLoading, hasError } = useChat(
   "CUSTOMER_ID",
   ["CORPUS_ID_1", "CORPUS_ID_2", "CORPUS_ID_N"],
   "API_KEY"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,8 +14,8 @@
     },
     "..": {
       "name": "@vectara/react-chatbot",
-      "version": "0.0.4",
-      "license": "MIT",
+      "version": "0.0.5",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -259,7 +259,7 @@ const App = () => {
 import { useChat } from "@vectara/react-chatbot/lib";
 
 export const App = () => {
-  const { sendMessage, resetConversation, messageHistory, isLoading, hasError } = useChat(
+  const { sendMessage, startNewConversation, messageHistory, isLoading, hasError } = useChat(
     DEFAULT_CUSTOMER_ID,
     DEFAULT_CORPUS_IDS,
     DEFAULT_API_KEY

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -278,7 +278,7 @@ export const App = () => {
               <p>The hook returns:</p>
               <ul>
                 <li>sendMessage - a function that sends a string to the Chat API endpoint</li>
-                <li>resetConversation - a function that resets the chat</li>
+                <li>startNewConversation - a function that resets the conversational context</li>
                 <li>messageHistory - an array of objects representing messages from the entire conversation</li>
                 <li>isLoading - a boolean value indicating whether or not a chat message request is pending</li>
                 <li>

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -259,7 +259,7 @@ const App = () => {
 import { useChat } from "@vectara/react-chatbot/lib";
 
 export const App = () => {
-  const { sendMessage, messageHistory, isLoading, hasError } = useChat(
+  const { sendMessage, resetConversation, messageHistory, isLoading, hasError } = useChat(
     DEFAULT_CUSTOMER_ID,
     DEFAULT_CORPUS_IDS,
     DEFAULT_API_KEY
@@ -278,6 +278,7 @@ export const App = () => {
               <p>The hook returns:</p>
               <ul>
                 <li>sendMessage - a function that sends a string to the Chat API endpoint</li>
+                <li>resetConversation - a function that resets the chat</li>
                 <li>messageHistory - an array of objects representing messages from the entire conversation</li>
                 <li>isLoading - a boolean value indicating whether or not a chat message request is pending</li>
                 <li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@vectara/react-chatbot",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/react-chatbot",
-      "version": "0.0.4",
-      "license": "MIT",
+      "version": "0.0.5",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -54,7 +54,7 @@ export const ChatView = ({
 }: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(isInitiallyOpen ?? false);
   const [query, setQuery] = useState<string>("");
-  const { sendMessage, resetConversation, messageHistory, isLoading, hasError } = useChat(
+  const { sendMessage, startNewConversation, messageHistory, isLoading, hasError } = useChat(
     customerId,
     corpusIds,
     apiKey
@@ -151,7 +151,7 @@ export const ChatView = ({
                   if (messageHistory[index]?.answer === "") {
                     spacer = null;
                   } else {
-                    spacer = index < chatItems.length - 1 ? <VuiSpacer size="m" /> : <VuiSpacer size="xl" />;
+                    spacer = index < chatItems.length - 1 ? <VuiSpacer size="m" /> : <VuiSpacer size="l" />;
                   }
                   return (
                     <Fragment key={index}>
@@ -162,8 +162,8 @@ export const ChatView = ({
                 })}
                 <VuiFlexContainer fullWidth={true} justifyContent="center">
                   <VuiFlexItem>
-                    <VuiButtonSecondary color="neutral" size="xs" onClick={resetConversation} isDisabled={isLoading}>
-                      Reset conversation
+                    <VuiButtonSecondary color="neutral" size="xs" onClick={startNewConversation} isDisabled={isLoading}>
+                      Start new conversation
                     </VuiButtonSecondary>
                   </VuiFlexItem>
                 </VuiFlexContainer>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1,5 +1,5 @@
-import { Fragment, ReactNode, useCallback, useEffect, useRef, useState } from "react";
-import { VuiFlexContainer, VuiFlexItem, VuiSpacer } from "../vui";
+import { Fragment, ReactNode, useEffect, useRef, useState } from "react";
+import { VuiButtonSecondary, VuiFlexContainer, VuiFlexItem, VuiSpacer } from "../vui";
 import { QueryInput } from "./QueryInput";
 import { ChatItem } from "./ChatItem";
 import { useChat } from "../useChat";
@@ -54,7 +54,11 @@ export const ChatView = ({
 }: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(isInitiallyOpen ?? false);
   const [query, setQuery] = useState<string>("");
-  const { sendMessage, messageHistory, isLoading, hasError } = useChat(customerId, corpusIds, apiKey);
+  const { sendMessage, resetConversation, messageHistory, isLoading, hasError } = useChat(
+    customerId,
+    corpusIds,
+    apiKey
+  );
   const appLayoutRef = useRef<HTMLDivElement>(null);
   const isScrolledToBottomRef = useRef(true);
 
@@ -156,6 +160,14 @@ export const ChatView = ({
                     </Fragment>
                   );
                 })}
+                <VuiFlexContainer fullWidth={true} justifyContent="center">
+                  <VuiFlexItem>
+                    <VuiButtonSecondary color="neutral" size="xs" onClick={resetConversation} isDisabled={isLoading}>
+                      Reset conversation
+                    </VuiButtonSecondary>
+                  </VuiFlexItem>
+                </VuiFlexContainer>
+                <VuiSpacer size="l" />
               </>
             )}
           </div>

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -97,6 +97,7 @@ describe("ReactChatbot", () => {
 
     expect(screen.getByShadowText("mock-question")).toBeInTheDocument();
     expect(screen.getByShadowText("mock-answer")).toBeInTheDocument();
+    expect(screen.getByShadowText("Reset conversation")).toBeInTheDocument();
   });
 
   it("should execute callback when sending message", () => {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -97,7 +97,7 @@ describe("ReactChatbot", () => {
 
     expect(screen.getByShadowText("mock-question")).toBeInTheDocument();
     expect(screen.getByShadowText("mock-answer")).toBeInTheDocument();
-    expect(screen.getByShadowText("Reset conversation")).toBeInTheDocument();
+    expect(screen.getByShadowText("Start new conversation")).toBeInTheDocument();
   });
 
   it("should execute callback when sending message", () => {

--- a/src/useChat.test.ts
+++ b/src/useChat.test.ts
@@ -81,7 +81,7 @@ describe("useChat", () => {
     expect(result.current.isLoading).toEqual(true);
   });
 
-  it("should reset the conversation", async () => {
+  it("should be able to reset the conversation", async () => {
     const { result } = renderHook(() => useChat("mock-customer-id", ["1"], "mock-api-key"));
     (sendSearchRequest as jest.Mock).mockImplementation(() => Promise.resolve(MOCK_API_RESPONSE));
 
@@ -115,7 +115,7 @@ describe("useChat", () => {
     );
 
     await act(async () => {
-      await result.current.resetConversation();
+      await result.current.startNewConversation();
     });
 
     expect(result.current.messageHistory.length).toEqual(0);

--- a/src/useChat.ts
+++ b/src/useChat.ts
@@ -95,6 +95,11 @@ export const useChat = (customerId: string, corpusIds: string[], apiKey: string)
     }
   };
 
+  const resetConversation = () => {
+    setMessageHistory([]);
+    setConversationId(undefined);
+  };
+
   useEffect(() => {
     if (!recentAnswer) return;
 
@@ -107,6 +112,7 @@ export const useChat = (customerId: string, corpusIds: string[], apiKey: string)
 
   return {
     sendMessage,
+    resetConversation,
     messageHistory,
     isLoading,
     hasError

--- a/src/useChat.ts
+++ b/src/useChat.ts
@@ -95,7 +95,7 @@ export const useChat = (customerId: string, corpusIds: string[], apiKey: string)
     }
   };
 
-  const resetConversation = () => {
+  const startNewConversation = () => {
     setMessageHistory([]);
     setConversationId(undefined);
   };
@@ -112,7 +112,7 @@ export const useChat = (customerId: string, corpusIds: string[], apiKey: string)
 
   return {
     sendMessage,
-    resetConversation,
+    startNewConversation,
     messageHistory,
     isLoading,
     hasError


### PR DESCRIPTION
## CONTEXT
We need a way to reset the chat conversation in the chatbot widget.

## CHANGES
- Add `resetConversation` as part of the `useChat` hook value
- Add a "Reset conversation" button to the chatbot window.
- Update documentation
- Update tests

## SCREENSHOT

<img width="607" alt="Screenshot 2024-03-15 at 1 39 51 PM" src="https://github.com/vectara/react-chatbot/assets/1464245/216c6203-0b9b-4dac-afbd-bb5bd40ed735">

