### PR TITLE
fix: Fix useChat import path in docs site

### DIFF
--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -250,7 +250,7 @@ const App = () => {
             <VuiSpacer size="s" />
             <VuiCode language="tsx">
               {`
-import { useChat } from "@vectara/react-chatbot/lib";
+import { useChat } from "@vectara/react-chatbot/lib/useChat";
 
 export const App = () => {
   const {


### PR DESCRIPTION
## CONTEXT
A hackathon participant discovered a typo in the `useChat` import path shown in our docs site.

## CHANGEs
- Update `useChat` import path to `@vectara/react-chatbot/lib/useChat`