### PR TITLE
feat: Add support for response language

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ import { ReactChatbot } from "@vectara/react-chatbot";
   isInitiallyOpen={false}
   zIndex={ /* (optional) number representing the z-index the component should have */ }
   enableStreaming={true}
+  language="fra"
 />
 ```
 
@@ -114,6 +115,11 @@ Customize the z-index of the chatbot widget
 
 Enable streaming responses from the Vectara API. Defaults to true.
 
+##### `language` (optional)
+
+The language the response should be in. Defaults to "eng" for English.
+See our [types](src/types.ts) for more information on supported language values.
+
 ### Use your own views with the useChat hook
 
 Install React-Chatbot:
@@ -134,7 +140,8 @@ const { sendMessage, activeMessage, messageHistory, isLoading, isStreamingRespon
     "CUSTOMER_ID",
     ["CORPUS_ID_1", "CORPUS_ID_2", "CORPUS_ID_N"],
     "API_KEY",
-    true // Enable streaming, false otherwise. Defaults to true.
+    true, // Enable streaming, false otherwise. Defaults to true.
+    "fra" // Response language. Defaults to "eng" for English. See our types for more information.
   );
 ```
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@vectara/react-chatbot",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^17.0.0",
@@ -35,7 +35,6 @@
         "@types/prismjs": "^1.26.3",
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/parser": "^5.50.0",
-        "axios": "^1.6.7",
         "chokidar": "^3.5.3",
         "cross-fetch": "^4.0.0",
         "esbuild": "^0.19.9",
@@ -61,7 +60,6 @@
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
-        "axios": "^1.6.7",
         "markdown-to-jsx": "^7.3.2",
         "react": ">= 17.0.2",
         "react-dom": ">= 17.0.2"
@@ -87,7 +85,6 @@
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/parser": "^5.50.0",
         "@vectara/stream-query-client": "^1.0.0",
-        "axios": "^1.6.7",
         "chokidar": "^3.5.3",
         "classnames": "^2.3.2",
         "cross-fetch": "^4.0.0",

--- a/docs/src/components/ConfigurationDrawer.tsx
+++ b/docs/src/components/ConfigurationDrawer.tsx
@@ -10,8 +10,13 @@ import {
   VuiToggle,
   VuiTextArea,
   VuiRadioButton,
-  VuiLabel
+  VuiLabel,
+  VuiSelect
 } from "../ui";
+
+import { SummaryLanguage } from "@vectara/react-chatbot";
+
+import { SUMMARY_LANGUAGES } from "../../../src/types";
 
 type Props = {
   isOpen: boolean;
@@ -32,6 +37,8 @@ type Props = {
   onUpdateEmptyMessagesContent: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   isStreamingEnabled: boolean;
   onUpdateIsStreamingEnabled: (isStreamingEnabled: boolean) => void;
+  language: SummaryLanguage;
+  onUpdateLanguage: (language: SummaryLanguage) => void;
 };
 
 export const ConfigurationDrawer = ({
@@ -52,7 +59,9 @@ export const ConfigurationDrawer = ({
   emptyMessagesContent,
   onUpdateEmptyMessagesContent,
   isStreamingEnabled,
-  onUpdateIsStreamingEnabled
+  onUpdateIsStreamingEnabled,
+  language,
+  onUpdateLanguage
 }: Props) => {
   return (
     <VuiDrawer
@@ -130,6 +139,21 @@ export const ConfigurationDrawer = ({
 
       <VuiSpacer size="m" />
 
+      <VuiFormGroup label="Response Language" labelFor="responseLanguage">
+        <VuiSelect
+          value={language}
+          onChange={(evt) => {
+            onUpdateLanguage(evt.target.value);
+          }}
+          options={SUMMARY_LANGUAGES.filter((lang) => lang !== "auto").map((lang) => ({
+            text: lang,
+            value: lang
+          }))}
+        />
+      </VuiFormGroup>
+
+      <VuiSpacer size="m" />
+
       <VuiLabel>Input size</VuiLabel>
 
       <VuiSpacer size="xs" />
@@ -149,6 +173,7 @@ export const ConfigurationDrawer = ({
         onChange={() => onUpdateInputSize("medium")}
         checked={inputSize === "medium"}
       />
+
       <VuiSpacer size="m" />
 
       <VuiFormGroup label="Empty messages content (JSX)" labelFor="emptyMessagesContent">

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, ReactNode, useCallback, useState } from "react";
 import ReactDOM from "react-dom";
 import { BiLogoGithub } from "react-icons/bi";
 import JsxParser from "react-jsx-parser";
-import { ReactChatbot } from "@vectara/react-chatbot";
+import { ReactChatbot, SummaryLanguage } from "@vectara/react-chatbot";
 import {
   VuiAppContent,
   VuiAppHeader,
@@ -39,7 +39,8 @@ const generateCodeSnippet = (
   placeholder?: string,
   inputSize?: string,
   emptyStateDisplay?: string,
-  isStreamingEnabled?: boolean
+  isStreamingEnabled?: boolean,
+  language?: SummaryLanguage
 ) => {
   const props = [
     `customerId="${customerId === "" ? "<Your Vectara customer ID>" : customerId}"`,
@@ -66,6 +67,8 @@ const generateCodeSnippet = (
   }
 
   props.push(`enableStreaming={${isStreamingEnabled}}`);
+
+  props.push(`language="${language}"`);
 
   props.push(`isInitiallyOpen={ /* (optional) true, if the component should be initially opened */ }`);
   props.push(`zIndex={ /* (optional) number representing the z-index the component should have */ }`);
@@ -97,6 +100,7 @@ const App = () => {
   const [placeholder, setPlaceholder] = useState<string>(DEFAULT_PLACEHOLDER);
   const [inputSize, setInputSize] = useState<"large" | "medium">("large");
   const [isStreamingEnabled, setIsStreamingEnabled] = useState<boolean>(true);
+  const [language, setLanguage] = useState<SummaryLanguage>("eng");
   const [emptyStateJsx, setEmptyStateJsx] = useState<string>("");
 
   const onUpdateCorpusIds = useCallback((e: ChangeEvent<HTMLInputElement>) => {
@@ -196,6 +200,7 @@ const App = () => {
               isInitiallyOpen={isChatbotForcedOpen}
               zIndex={9}
               enableStreaming={isStreamingEnabled}
+              language={language}
             />
             <VuiSpacer size="m" />
             <VuiButtonSecondary
@@ -232,7 +237,8 @@ const App = () => {
                 placeholder,
                 inputSize,
                 emptyStateJsx,
-                isStreamingEnabled
+                isStreamingEnabled,
+                language
               )}
             </VuiCode>
             <VuiSpacer size="xxl" />
@@ -265,7 +271,8 @@ export const App = () => {
     DEFAULT_CUSTOMER_ID,
     DEFAULT_CORPUS_IDS,
     DEFAULT_API_KEY,
-    true // Enable streaming, false otherwise. Defaults to true.
+    true, // Enable streaming, false otherwise. Defaults to true.
+    "fra" // Response language. Defaults to "eng" for English.
   );
 
   /* You can pass the values returned by the hook to your custom components as props, or use them
@@ -318,6 +325,8 @@ export const App = () => {
               onUpdateEmptyMessagesContent={onUpdateEmptyMessagesContent}
               isStreamingEnabled={isStreamingEnabled}
               onUpdateIsStreamingEnabled={setIsStreamingEnabled}
+              language={language}
+              onUpdateLanguage={setLanguage}
             />
           </div>
         </VuiAppContent>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/react-chatbot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/react-chatbot",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^17.0.0",
@@ -27,7 +27,6 @@
         "@types/prismjs": "^1.26.3",
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/parser": "^5.50.0",
-        "axios": "^1.6.7",
         "chokidar": "^3.5.3",
         "cross-fetch": "^4.0.0",
         "esbuild": "^0.19.9",
@@ -53,7 +52,6 @@
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
-        "axios": "^1.6.7",
         "markdown-to-jsx": "^7.3.2",
         "react": ">= 17.0.2",
         "react-dom": ">= 17.0.2"
@@ -2936,17 +2934,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -5016,26 +5003,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/for-each": {
@@ -9317,12 +9284,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/proxy-middleware": {
       "version": "0.15.0",

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -5,7 +5,7 @@ import { ChatItem } from "./ChatItem";
 import { useChat } from "../useChat";
 import { Loader } from "./Loader";
 import { ChatBubbleIcon, MinimizeIcon } from "./Icons";
-import { debounce } from "lodash";
+import { SummaryLanguage } from "types";
 
 const inputSizeToQueryInputSize = {
   large: "l",
@@ -30,6 +30,7 @@ interface Props {
   corpusIds: string[];
   apiKey: string;
   enableStreaming: boolean;
+  language: SummaryLanguage;
   title?: string;
   placeholder?: string;
   inputSize?: "large" | "medium";
@@ -53,12 +54,13 @@ export const ChatView = ({
   emptyStateDisplay = <DefaultEmptyMessagesState />,
   isInitiallyOpen,
   zIndex = 9999,
-  enableStreaming
+  enableStreaming,
+  language
 }: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(isInitiallyOpen ?? false);
   const [query, setQuery] = useState<string>("");
   const { sendMessage, startNewConversation, messageHistory, isLoading, hasError, activeMessage, isStreamingResponse } =
-    useChat(customerId, corpusIds, apiKey, enableStreaming);
+    useChat(customerId, corpusIds, apiKey, enableStreaming, language);
 
   const appLayoutRef = useRef<HTMLDivElement>(null);
   const isScrolledToBottomRef = useRef(true);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { ChatView } from "components/ChatView";
 
 // @ts-ignore
 import cssText from "index.scss";
+import type { SummaryLanguage } from "./types";
 
 export interface Props {
   // Vectara customer ID
@@ -35,6 +36,9 @@ export interface Props {
 
   // Used to enable streaming responses from the API. Defaults to true.
   enableStreaming?: boolean;
+
+  // The language the responses should be in. Defaults to English.
+  language?: SummaryLanguage;
 }
 
 /**
@@ -50,7 +54,8 @@ const ReactChatbotInternal: FC<Props> = ({
   emptyStateDisplay,
   isInitiallyOpen,
   zIndex,
-  enableStreaming = true
+  enableStreaming = true,
+  language = "eng"
 }) => {
   return (
     <div>
@@ -65,6 +70,7 @@ const ReactChatbotInternal: FC<Props> = ({
         isInitiallyOpen={isInitiallyOpen}
         zIndex={zIndex}
         enableStreaming={enableStreaming}
+        language={language}
       />
     </div>
   );
@@ -96,7 +102,8 @@ class ReactChatbotWebComponent extends HTMLElement {
       "isinitiallyopen",
       "zindex",
       "emptystatedisplayupdatetime",
-      "enablestreaming"
+      "enablestreaming",
+      "language"
     ];
   }
 
@@ -139,7 +146,9 @@ class ReactChatbotWebComponent extends HTMLElement {
     const isInitiallyOpen = this.getAttribute("isInitiallyOpen") === "true";
     const emptyStateDisplay = this.emptyStateDisplay ?? undefined;
     const zIndex = this.getAttribute("zIndex") !== null ? parseInt(this.getAttribute("zIndex")!) : undefined;
-    const enableStreaming = this.getAttribute("enableStreaming") == "true";
+    const enableStreaming =
+      this.getAttribute("enableStreaming") !== null ? this.getAttribute("enableStreaming") == "true" : undefined;
+    const language = (this.getAttribute("language") as SummaryLanguage) ?? undefined;
 
     ReactDOM.render(
       <>
@@ -154,6 +163,7 @@ class ReactChatbotWebComponent extends HTMLElement {
           isInitiallyOpen={isInitiallyOpen}
           zIndex={zIndex}
           enableStreaming={enableStreaming}
+          language={language}
         />
       </>,
       this.mountPoint
@@ -196,3 +206,5 @@ export const ReactChatbot = (props: Props) => {
   // @ts-ignore
   return <react-chatbot ref={ref} {...updatedProps} />;
 };
+
+export { SummaryLanguage };

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ type SearchResponseSummary = {
   status?: string;
 };
 
-const SUMMARY_LANGUAGES = [
+export const SUMMARY_LANGUAGES = [
   "auto",
   "eng",
   "deu",

--- a/src/useChat.ts
+++ b/src/useChat.ts
@@ -14,7 +14,13 @@ import { deserializeSearchResponse } from "utils/deserializeSearchResponse";
  *  - startNewConversation: a utility method for clearing the chat context
  *  - hasError: a boolean indicating an error was encountered while sending a message to the platform
  */
-export const useChat = (customerId: string, corpusIds: string[], apiKey: string, useStreaming: boolean = true) => {
+export const useChat = (
+  customerId: string,
+  corpusIds: string[],
+  apiKey: string,
+  useStreaming: boolean = true,
+  language: SummaryLanguage = "eng"
+) => {
   const [messageHistory, setMessageHistory] = useState<ChatTurn[]>([]);
   const recentQuestion = useRef<string>("");
   const [activeMessage, setActiveMessage] = useState<ChatTurn | null>(null);
@@ -22,8 +28,6 @@ export const useChat = (customerId: string, corpusIds: string[], apiKey: string,
   const [isStreamingResponse, setIsStreamingResponse] = useState<boolean>(false);
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [hasError, setHasError] = useState<boolean>(false);
-
-  const getLanguage = (languageValue?: string): SummaryLanguage => (languageValue ?? "eng") as SummaryLanguage;
 
   const sendMessage = async ({ query, isRetry = false }: { query: string; isRetry?: boolean }) => {
     if (isLoading) return;
@@ -67,7 +71,7 @@ export const useChat = (customerId: string, corpusIds: string[], apiKey: string,
             summaryNumResults: 7,
             summaryNumSentences: 3,
             summaryPromptName: "vectara-summary-ext-v1.2.0",
-            language: getLanguage(),
+            language,
             chat: { store: true, conversationId: conversationId ?? undefined }
           },
           (update) => onStreamUpdate(update)
@@ -89,7 +93,7 @@ export const useChat = (customerId: string, corpusIds: string[], apiKey: string,
           summaryNumResults: 7,
           summaryNumSentences: 3,
           summaryPromptName: "vectara-summary-ext-v1.2.0",
-          language: getLanguage(),
+          language,
           chat: { conversationId: conversationId ?? undefined }
         });
 


### PR DESCRIPTION
## CONTEXT
Hackathon participants have surfaced the immediate need to support response language.

## CHANGES
- add language support in ReactChatbot props
- add language support to `useChat` hook
- update docs site
- update README
- fix a small bug where streaming is not enabled by default