### PR TITLE
Add support for summaryPromptName and enableFactualConsistencyScore. Change useChat to expect a config object. Bump to 3.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ import { useChat } from "@vectara/react-chatbot/lib/useChat";
 /* snip */
 
 const { sendMessage, activeMessage, messageHistory, isLoading, isStreamingResponse, hasError, startNewConversation } =
-  useChat(
-    "CUSTOMER_ID",
-    ["CORPUS_ID_1", "CORPUS_ID_2", "CORPUS_ID_N"],
-    "API_KEY",
-    true, // Enable streaming, false otherwise. Defaults to true.
-    "fra" // Response language. Defaults to "eng" for English. See our types for more information.
-  );
+  useChat({
+    customerId: "CUSTOMER_ID",
+    corpusIds: ["CORPUS_ID_1", "CORPUS_ID_2", "CORPUS_ID_N"],
+    apiKey: "API_KEY",
+    enableStreaming: true, // Enable streaming, false otherwise. Defaults to true.
+    language: "fra" // Response language. Defaults to "eng" for English. See our types for more information.
+  });
 ```
 
 The values returned by the hook can be passed on to your custom components as props or used in any way you wish.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@vectara/react-chatbot",
-      "version": "1.1.1",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^17.0.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
-        "@vectara/stream-query-client": "^1.0.0",
+        "@vectara/stream-query-client": "^2.0.2",
         "classnames": "^2.3.2",
         "lodash": "^4.17.21",
         "prismjs": "^1.29.0",
@@ -84,7 +84,7 @@
         "@types/react-dom": "^17.0.0",
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/parser": "^5.50.0",
-        "@vectara/stream-query-client": "^1.0.0",
+        "@vectara/stream-query-client": "^2.0.2",
         "chokidar": "^3.5.3",
         "classnames": "^2.3.2",
         "cross-fetch": "^4.0.0",

--- a/docs/src/components/ConfigurationDrawer.tsx
+++ b/docs/src/components/ConfigurationDrawer.tsx
@@ -41,6 +41,10 @@ type Props = {
   onUpdateLanguage: (language: SummaryLanguage) => void;
   exampleQuestions: string;
   onUpdateExampleQuestions: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  enableFactualConsistencyScore: boolean;
+  onUpdateEnableFactualConsistencyScore: (enableFactualConsistencyScore: boolean) => void;
+  summaryPromptName: string;
+  onUpdateSummaryPromptName: (summaryPromptName: string) => void;
 };
 
 export const ConfigurationDrawer = ({
@@ -65,7 +69,11 @@ export const ConfigurationDrawer = ({
   language,
   onUpdateLanguage,
   exampleQuestions,
-  onUpdateExampleQuestions
+  onUpdateExampleQuestions,
+  enableFactualConsistencyScore,
+  onUpdateEnableFactualConsistencyScore,
+  summaryPromptName,
+  onUpdateSummaryPromptName
 }: Props) => {
   return (
     <VuiDrawer
@@ -136,7 +144,7 @@ export const ConfigurationDrawer = ({
 
       <VuiSpacer size="m" />
 
-      <VuiLabel>Enable Streaming</VuiLabel>
+      <VuiLabel>Enable streaming</VuiLabel>
 
       <VuiSpacer size="xs" />
 
@@ -149,7 +157,7 @@ export const ConfigurationDrawer = ({
 
       <VuiSpacer size="m" />
 
-      <VuiFormGroup label="Response Language" labelFor="responseLanguage">
+      <VuiFormGroup label="Response language" labelFor="responseLanguage">
         <VuiSelect
           value={language}
           onChange={(evt) => {
@@ -188,6 +196,25 @@ export const ConfigurationDrawer = ({
 
       <VuiFormGroup label="Empty messages content (JSX)" labelFor="emptyMessagesContent">
         <VuiTextArea value={emptyMessagesContent} onChange={onUpdateEmptyMessagesContent} fullWidth />
+      </VuiFormGroup>
+
+      <VuiSpacer size="m" />
+
+      <VuiLabel>Enable Factual Consistency Score</VuiLabel>
+
+      <VuiSpacer size="xs" />
+
+      <VuiToggle
+        onChange={(e) => {
+          onUpdateEnableFactualConsistencyScore(e.target.checked);
+        }}
+        checked={enableFactualConsistencyScore}
+      />
+
+      <VuiSpacer size="m" />
+
+      <VuiFormGroup label="Summary prompt name" labelFor="summaryPromptName">
+        <VuiTextInput value={summaryPromptName} onChange={(e) => onUpdateSummaryPromptName(e.target.value)} fullWidth />
       </VuiFormGroup>
 
       <VuiSpacer size="l" />

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -1,8 +1,8 @@
-import { ChangeEvent, ReactNode, useCallback, useState } from "react";
+import { ChangeEvent, useCallback, useState } from "react";
 import ReactDOM from "react-dom";
 import { BiLogoGithub } from "react-icons/bi";
 import JsxParser from "react-jsx-parser";
-import { ReactChatbot, SummaryLanguage } from "@vectara/react-chatbot";
+import { ReactChatbot, SummaryLanguage, DEFAULT_SUMMARIZER } from "@vectara/react-chatbot";
 import {
   VuiAppContent,
   VuiAppHeader,
@@ -113,6 +113,8 @@ const App = () => {
   const [language, setLanguage] = useState<SummaryLanguage>("eng");
   const [emptyStateJsx, setEmptyStateJsx] = useState<string>("");
   const [exampleQuestions, setExampleQuestions] = useState<string>("What is Vectara?, How does RAG work?");
+  const [enableFactualConsistencyScore, setEnableFactualConsistencyScore] = useState<boolean>(false);
+  const [summaryPromptName, setSummaryPromptName] = useState<string>(DEFAULT_SUMMARIZER);
 
   const onUpdateCorpusIds = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const sanitizedValue = e.target.value.trim();
@@ -202,6 +204,7 @@ const App = () => {
               <p>React-Chatbot instantly adds a Vectara-powered chatbot to your React applications.</p>
             </VuiText>
             <VuiSpacer size="m" />
+
             {/**
              * Here we ensure that if the field is blank, we use the default props that point to the docs page.
              * This ensures that we don't voluntarily display the docs corpus details in the text fields.
@@ -219,7 +222,10 @@ const App = () => {
               zIndex={9}
               enableStreaming={isStreamingEnabled}
               language={language}
+              enableFactualConsistencyScore={enableFactualConsistencyScore}
+              summaryPromptName={summaryPromptName}
             />
+
             <VuiSpacer size="m" />
             <VuiButtonSecondary
               color="primary"
@@ -246,6 +252,7 @@ const App = () => {
             <VuiSpacer size="m" />
             <VuiCode>npm install @vectara/react-chatbot</VuiCode>
             <VuiSpacer size="s" />
+
             <VuiCode language="tsx">
               {generateCodeSnippet(
                 customerId,
@@ -260,6 +267,7 @@ const App = () => {
                 exampleQuestions
               )}
             </VuiCode>
+
             <VuiSpacer size="xxl" />
             <VuiTitle size="m">
               <h2>Create your own view</h2>
@@ -273,6 +281,7 @@ const App = () => {
               <p>Check out the example below.</p>
             </VuiText>
             <VuiSpacer size="s" />
+
             <VuiCode language="tsx">
               {`
 import { useChat } from "@vectara/react-chatbot/lib/useChat";
@@ -286,19 +295,20 @@ export const App = () => {
     isStreamingResponse,
     hasError
     startNewConversation
-  } = useChat(
-    DEFAULT_CUSTOMER_ID,
-    DEFAULT_CORPUS_IDS,
-    DEFAULT_API_KEY,
-    true, // Enable streaming, false otherwise. Defaults to true.
-    "fra" // Response language. Defaults to "eng" for English.
-  );
+  } = useChat({
+    customerId: DEFAULT_CUSTOMER_ID,
+    corpusIds: DEFAULT_CORPUS_IDS,
+    apiKey: DEFAULT_API_KEY,
+    enableStreaming: true, // Enable streaming, false otherwise. Defaults to true.
+    language: "fra" // Response language. Defaults to "eng" for English.
+  });
 
   /* You can pass the values returned by the hook to your custom components as props, or use them
   however you wish. */
 };
 `}
             </VuiCode>
+
             <VuiSpacer size="m" />
             <VuiText>
               <p></p>
@@ -325,6 +335,7 @@ export const App = () => {
                 read the docs.
               </VuiLink>
             </VuiText>
+
             <ConfigurationDrawer
               isOpen={isConfigurationDrawerOpen}
               onClose={() => setIsConfigurationDrawerOpen(false)}
@@ -348,6 +359,10 @@ export const App = () => {
               onUpdateLanguage={setLanguage}
               exampleQuestions={exampleQuestions}
               onUpdateExampleQuestions={onUpdateExampleQuestions}
+              enableFactualConsistencyScore={enableFactualConsistencyScore}
+              onUpdateEnableFactualConsistencyScore={setEnableFactualConsistencyScore}
+              summaryPromptName={summaryPromptName}
+              onUpdateSummaryPromptName={setSummaryPromptName}
             />
           </div>
         </VuiAppContent>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
-        "@vectara/stream-query-client": "^1.0.0",
+        "@vectara/stream-query-client": "^2.0.2",
         "classnames": "^2.3.2",
         "lodash": "^4.17.21",
         "prismjs": "^1.29.0",
@@ -2526,9 +2526,9 @@
       "dev": true
     },
     "node_modules/@vectara/stream-query-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vectara/stream-query-client/-/stream-query-client-1.0.0.tgz",
-      "integrity": "sha512-S6KA/zzUDGoG7hEzQ/XTpk6NVy2Tru/zUJnuWQbNTr0Lc9fhM30VrlohtxId+8ojP3kYxCZpply7R0leC1RtgA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vectara/stream-query-client/-/stream-query-client-2.0.2.tgz",
+      "integrity": "sha512-Z9WRpHz5XMPwr4miQhh2QgwOkoDdi+ThSc/26rg8VDYvp2pxKmOjpnME1O4JIR+IXpLtfJJmo65usmViAJxMjA=="
     },
     "node_modules/abab": {
       "version": "2.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/react-chatbot",
-  "version": "1.1.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/react-chatbot",
-      "version": "1.1.1",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "@vectara/stream-query-client": "^1.0.0",
+    "@vectara/stream-query-client": "^2.0.2",
     "classnames": "^2.3.2",
     "lodash": "^4.17.21",
     "prismjs": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/react-chatbot",
-  "version": "3.0.0",
+  "version": "1.2.1",
   "description": "A Vectara-powered Chatbot component",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/react-chatbot",
-  "version": "1.2.1",
+  "version": "3.0.0",
   "description": "A Vectara-powered Chatbot component",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/components/ChatItem.tsx
+++ b/src/components/ChatItem.tsx
@@ -38,6 +38,7 @@ type Props = {
   question?: string;
   answer?: string;
   searchResults?: DeserializedSearchResult[];
+  factualConsistencyScore?: React.ReactNode;
   onRetry?: () => void;
   isStreaming?: boolean;
 };
@@ -47,7 +48,7 @@ type Props = {
  * Defaults to showing just the user-supplied message, if it has not yet been answered.
  * Otherwise, shows both question and answer, plus applicable references.
  */
-export const ChatItem = ({ question, answer, searchResults, onRetry, isStreaming }: Props) => {
+export const ChatItem = ({ question, answer, searchResults, factualConsistencyScore, onRetry, isStreaming }: Props) => {
   const [isReferencesOpen, setIsReferencesOpen] = useState(false);
   let content;
 
@@ -113,6 +114,13 @@ export const ChatItem = ({ question, answer, searchResults, onRetry, isStreaming
               </span>
             )}
           </VuiText>
+
+          {factualConsistencyScore && (
+            <>
+              <VuiSpacer size="xs" />
+              {factualConsistencyScore}
+            </>
+          )}
 
           {reorderedSearchResults && reorderedSearchResults.length > 0 && (
             <>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -5,8 +5,9 @@ import { ChatItem } from "./ChatItem";
 import { useChat } from "../useChat";
 import { Loader } from "./Loader";
 import { MinimizeIcon } from "./Icons";
-import { SummaryLanguage } from "types";
+import { FactualConsistencyBadge } from "./FactualConsistencyBadge";
 import { ExampleQuestions } from "./exampleQuestions/ExampleQuestions";
+import { SummaryLanguage } from "types";
 
 const inputSizeToQueryInputSize = {
   large: "l",
@@ -134,7 +135,7 @@ export const ChatView = ({
   const historyItems = useMemo(
     () =>
       messageHistory.map((turn, index) => {
-        const { question, answer, results } = turn;
+        const { question, answer, results, factualConsistencyScore } = turn;
         const onRetry =
           hasError && index === messageHistory.length - 1
             ? () => sendMessage({ query: question, isRetry: true })
@@ -142,7 +143,15 @@ export const ChatView = ({
 
         return (
           <Fragment key={index}>
-            <ChatItem question={question} answer={answer} searchResults={results} onRetry={onRetry} />
+            <ChatItem
+              question={question}
+              answer={answer}
+              searchResults={results}
+              factualConsistencyScore={
+                enableFactualConsistencyScore && <FactualConsistencyBadge score={factualConsistencyScore} />
+              }
+              onRetry={onRetry}
+            />
             {index < messageHistory.length - 1 && <VuiSpacer size="m" />}
           </Fragment>
         );
@@ -195,6 +204,11 @@ export const ChatView = ({
                       question={activeMessage.question}
                       answer={activeMessage.answer}
                       searchResults={activeMessage.results}
+                      factualConsistencyScore={
+                        enableFactualConsistencyScore && (
+                          <FactualConsistencyBadge score={activeMessage.factualConsistencyScore} />
+                        )
+                      }
                       onRetry={
                         hasError ? () => sendMessage({ query: activeMessage.question, isRetry: true }) : undefined
                       }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -13,19 +13,48 @@ const inputSizeToQueryInputSize = {
   medium: "m"
 } as const;
 
-interface Props {
+export interface Props {
+  // Vectara customer ID
   customerId: string;
-  corpusIds: string[];
+
+  // Vectara API key
   apiKey: string;
-  enableStreaming: boolean;
-  language: SummaryLanguage;
+
+  // Vectara corpus IDs
+  corpusIds: string[];
+
+  // Title to be shown in the UI header
   title?: string;
+
+  // Text to be shown when the input field has no text
   placeholder?: string;
+
+  // Example questions to prompt the user
   exampleQuestions?: string[];
+
+  // Size of input. Defaults to "large".
   inputSize?: "large" | "medium";
+
+  // Content to render into the messages display when there are no messages to show
   emptyStateDisplay?: ReactNode;
+
+  // Configures the component's initial open/closed state.
   isInitiallyOpen?: boolean;
+
+  // Defines the component's z-index. Defaults to 9999.
   zIndex?: number;
+
+  // Enables streaming responses from the API. Defaults to true.
+  enableStreaming?: boolean;
+
+  // The language the responses should be in. Defaults to English.
+  language?: SummaryLanguage;
+
+  // Enables the factual consistency score in the API response. Defaults to false.
+  enableFactualConsistencyScore?: boolean;
+
+  // Defines the name of the summary prompt. Defaults to "vectara-summary-ext-v1.2.0".
+  summaryPromptName?: string;
 }
 
 /**
@@ -44,13 +73,23 @@ export const ChatView = ({
   emptyStateDisplay,
   isInitiallyOpen,
   zIndex = 9999,
-  enableStreaming,
-  language
+  enableStreaming = true,
+  language = "eng",
+  enableFactualConsistencyScore,
+  summaryPromptName
 }: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(isInitiallyOpen ?? false);
   const [query, setQuery] = useState<string>("");
   const { sendMessage, startNewConversation, messageHistory, isLoading, hasError, activeMessage, isStreamingResponse } =
-    useChat(customerId, corpusIds, apiKey, enableStreaming, language);
+    useChat({
+      customerId,
+      corpusIds,
+      apiKey,
+      enableStreaming,
+      language,
+      enableFactualConsistencyScore,
+      summaryPromptName
+    });
 
   const appLayoutRef = useRef<HTMLDivElement>(null);
   const isScrolledToBottomRef = useRef(true);

--- a/src/components/FactualConsistencyBadge.tsx
+++ b/src/components/FactualConsistencyBadge.tsx
@@ -1,0 +1,47 @@
+import { VuiBadge, VuiFlexContainer, VuiLink, VuiSpinner, VuiText } from "../vui";
+
+interface Props {
+  score?: number;
+}
+
+export const FactualConsistencyBadge = ({ score }: Props) => {
+  let badge;
+
+  if (score === undefined) {
+    badge = <VuiBadge color="accent">Calculating Factual Consistency Score…</VuiBadge>;
+  } else {
+    const sanitizedScore = parseFloat(score.toFixed(2));
+    let badgeColor = "neutral";
+
+    if (sanitizedScore === 0) {
+      badgeColor = "danger";
+    } else if (sanitizedScore === 1) {
+      badgeColor = "success";
+    }
+
+    badge = (
+      <VuiBadge color={badgeColor as "neutral" | "success" | "danger"}>
+        Factual Consistency Score: {sanitizedScore}
+      </VuiBadge>
+    );
+  }
+
+  return (
+    <VuiFlexContainer alignItems="center" data-testid="factualConsistencyBadge">
+      {score === undefined && <VuiSpinner size="s" />}
+
+      {badge}
+
+      <VuiText size="xs">
+        <p>
+          <VuiLink
+            href="https://docs.vectara.com/docs/api-reference/search-apis/search?#factual-consistency-score"
+            target="_blank"
+          >
+            What's this?
+          </VuiLink>
+        </p>
+      </VuiText>
+    </VuiFlexContainer>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,99 +1,19 @@
-import React, { FC, ReactNode, useEffect, useRef } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 import * as ReactDOM from "react-dom";
-import { ChatView } from "components/ChatView";
+import { Props, ChatView } from "./components/ChatView";
+import type { SummaryLanguage } from "./types";
+export type { Props } from "components/ChatView";
+export { DEFAULT_SUMMARIZER } from "./useChat";
 
 // @ts-ignore
 import cssText from "index.scss";
-import type { SummaryLanguage } from "./types";
-
-export interface Props {
-  // Vectara customer ID
-  customerId: string;
-
-  // Vectara API key
-  apiKey: string;
-
-  // Vectara corpus IDs
-  corpusIds: string[];
-
-  // Title to be shown in the UI header
-  title?: string;
-
-  // Text to be shown when the input field has no text
-  placeholder?: string;
-
-  // Example questions to prompt the user
-  exampleQuestions?: string[];
-
-  // Size of input. Defaults to "large".
-  inputSize?: "large" | "medium";
-
-  // Content to render into the messages display when there are no messages to show
-  emptyStateDisplay?: ReactNode;
-
-  // Used to explicitly configure the component's initial open/closed state.
-  isInitiallyOpen?: boolean;
-
-  // Used to control the component's z-index. Defaults to 9999.
-  zIndex?: number;
-
-  // Used to enable streaming responses from the API. Defaults to true.
-  enableStreaming?: boolean;
-
-  // The language the responses should be in. Defaults to English.
-  language?: SummaryLanguage;
-}
-
-/**
- * A client-side chat component that queries specific corpora with a user-provided message.
- */
-const ReactChatbotInternal: FC<Props> = ({
-  customerId,
-  apiKey,
-  corpusIds,
-  title,
-  placeholder,
-  exampleQuestions,
-  inputSize,
-  emptyStateDisplay,
-  isInitiallyOpen,
-  zIndex,
-  enableStreaming = true,
-  language = "eng"
-}) => {
-  return (
-    <div>
-      <ChatView
-        customerId={customerId}
-        corpusIds={corpusIds}
-        apiKey={apiKey}
-        title={title}
-        placeholder={placeholder}
-        exampleQuestions={exampleQuestions}
-        inputSize={inputSize}
-        emptyStateDisplay={emptyStateDisplay}
-        isInitiallyOpen={isInitiallyOpen}
-        zIndex={zIndex}
-        enableStreaming={enableStreaming}
-        language={language}
-      />
-    </div>
-  );
-};
 
 class ReactChatbotWebComponent extends HTMLElement {
   sheet!: CSSStyleSheet;
   sr!: ShadowRoot;
   mountPoint!: HTMLDivElement;
 
-  // Props
-  customerId!: string;
-  corpusIds!: string[];
-  apiKey!: string;
-  title!: string;
-  placeholder!: string;
-  isInitiallyOpen!: boolean;
-  zIndex!: number;
+  // References
   emptyStateDisplay!: ReactNode;
 
   static get observedAttributes() {
@@ -109,7 +29,9 @@ class ReactChatbotWebComponent extends HTMLElement {
       "zindex",
       "emptystatedisplayupdatetime",
       "enablestreaming",
-      "language"
+      "language",
+      "enablefactualconsistencyscore",
+      "summarypromptname"
     ];
   }
 
@@ -157,24 +79,28 @@ class ReactChatbotWebComponent extends HTMLElement {
     const enableStreaming =
       this.getAttribute("enableStreaming") !== null ? this.getAttribute("enableStreaming") == "true" : undefined;
     const language = (this.getAttribute("language") as SummaryLanguage) ?? undefined;
+    const enableFactualConsistencyScore = this.getAttribute("enableFactualConsistencyScore") === "true";
+    const summaryPromptName = this.getAttribute("summaryPromptName") ?? undefined;
 
     ReactDOM.render(
-      <>
-        <ReactChatbotInternal
+      <div>
+        <ChatView
           customerId={customerId}
           corpusIds={corpusIds}
           apiKey={apiKey}
           title={title}
           placeholder={placeholder}
           exampleQuestions={exampleQuestions}
-          inputSize={inputSize as "large" | "medium" | undefined}
+          inputSize={inputSize as Props["inputSize"]}
           emptyStateDisplay={emptyStateDisplay}
           isInitiallyOpen={isInitiallyOpen}
           zIndex={zIndex}
           enableStreaming={enableStreaming}
           language={language}
+          enableFactualConsistencyScore={enableFactualConsistencyScore}
+          summaryPromptName={summaryPromptName}
         />
-      </>,
+      </div>,
       this.mountPoint
     );
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,4 +93,5 @@ export type ChatTurn = {
   question: string;
   answer: string;
   results: DeserializedSearchResult[];
+  factualConsistencyScore?: number;
 };

--- a/src/useChat.test.ts
+++ b/src/useChat.test.ts
@@ -45,7 +45,9 @@ const MOCK_API_RESPONSE = {
 describe("useChat", () => {
   describe("streaming", () => {
     it("should send messages and update hook values", async () => {
-      const { result } = renderHook(() => useChat("mock-customer-id", ["1"], "mock-api-key"));
+      const { result } = renderHook(() =>
+        useChat({ customerId: "mock-customer-id", corpusIds: ["1"], apiKey: "mock-api-key" })
+      );
 
       (streamQuery as jest.Mock).mockImplementation(async (_, onStreamUpdate) => {
         await onStreamUpdate({
@@ -91,7 +93,9 @@ describe("useChat", () => {
 
   describe("non-streaming", () => {
     it("should send messages and update message history", async () => {
-      const { result } = renderHook(() => useChat("mock-customer-id", ["1"], "mock-api-key", false));
+      const { result } = renderHook(() =>
+        useChat({ customerId: "mock-customer-id", corpusIds: ["1"], apiKey: "mock-api-key", enableStreaming: false })
+      );
 
       (sendSearchRequest as jest.Mock).mockImplementation(() => Promise.resolve(MOCK_API_RESPONSE));
 
@@ -109,7 +113,9 @@ describe("useChat", () => {
     });
 
     it("should reflect error state", async () => {
-      const { result } = renderHook(() => useChat("mock-customer-id", ["1"], "mock-api-key", false));
+      const { result } = renderHook(() =>
+        useChat({ customerId: "mock-customer-id", corpusIds: ["1"], apiKey: "mock-api-key", enableStreaming: false })
+      );
       (sendSearchRequest as jest.Mock).mockImplementation(() => {
         throw "error";
       });
@@ -122,7 +128,9 @@ describe("useChat", () => {
     });
 
     it("should reflect loading state", async () => {
-      const { result } = renderHook(() => useChat("mock-customer-id", ["1"], "mock-api-key"));
+      const { result } = renderHook(() =>
+        useChat({ customerId: "mock-customer-id", corpusIds: ["1"], apiKey: "mock-api-key" })
+      );
       (sendSearchRequest as jest.Mock).mockImplementation(() => {
         return new Promise(() => {});
       });
@@ -136,7 +144,9 @@ describe("useChat", () => {
   });
 
   it("should be able to reset the conversation", async () => {
-    const { result } = renderHook(() => useChat("mock-customer-id", ["1"], "mock-api-key", false));
+    const { result } = renderHook(() =>
+      useChat({ customerId: "mock-customer-id", corpusIds: ["1"], apiKey: "mock-api-key", enableStreaming: false })
+    );
     (sendSearchRequest as jest.Mock).mockImplementation(() => Promise.resolve(MOCK_API_RESPONSE));
 
     await act(async () => {

--- a/src/useChat.ts
+++ b/src/useChat.ts
@@ -14,13 +14,28 @@ import { deserializeSearchResponse } from "utils/deserializeSearchResponse";
  *  - startNewConversation: a utility method for clearing the chat context
  *  - hasError: a boolean indicating an error was encountered while sending a message to the platform
  */
-export const useChat = (
-  customerId: string,
-  corpusIds: string[],
-  apiKey: string,
-  useStreaming: boolean = true,
-  language: SummaryLanguage = "eng"
-) => {
+
+export const DEFAULT_SUMMARIZER = "vectara-summary-ext-v1.2.0";
+
+type UseChatConfig = {
+  customerId: string;
+  corpusIds: string[];
+  apiKey: string;
+  enableStreaming?: boolean;
+  language?: SummaryLanguage;
+  enableFactualConsistencyScore?: boolean;
+  summaryPromptName?: string;
+};
+
+export const useChat = ({
+  customerId,
+  corpusIds,
+  apiKey,
+  enableStreaming = true,
+  language = "eng",
+  enableFactualConsistencyScore,
+  summaryPromptName = DEFAULT_SUMMARIZER
+}: UseChatConfig) => {
   const [messageHistory, setMessageHistory] = useState<ChatTurn[]>([]);
   const recentQuestion = useRef<string>("");
   const [activeMessage, setActiveMessage] = useState<ChatTurn | null>(null);
@@ -62,7 +77,7 @@ export const useChat = (
 
     setIsLoading(true);
 
-    if (useStreaming) {
+    if (enableStreaming) {
       try {
         await streamQuery(
           {
@@ -70,8 +85,9 @@ export const useChat = (
             corpusIds,
             summaryNumResults: 7,
             summaryNumSentences: 3,
-            summaryPromptName: "vectara-summary-ext-v1.2.0",
+            summaryPromptName,
             language,
+            enableFactualConsistencyScore,
             chat: { store: true, conversationId: conversationId ?? undefined }
           },
           (update) => onStreamUpdate(update)
@@ -92,8 +108,9 @@ export const useChat = (
           summaryMode: true,
           summaryNumResults: 7,
           summaryNumSentences: 3,
-          summaryPromptName: "vectara-summary-ext-v1.2.0",
+          summaryPromptName,
           language,
+          enableFactualConsistencyScore,
           chat: { conversationId: conversationId ?? undefined }
         });
 

--- a/src/useChat.ts
+++ b/src/useChat.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { ChatTurn, SummaryLanguage } from "types";
-import { ChatDetail, FactualConsistencyDetail, streamQuery, StreamUpdate } from "@vectara/stream-query-client";
+import { streamQuery, StreamUpdate } from "@vectara/stream-query-client";
 import { sendSearchRequest } from "utils/sendSearchRequest";
 import { deserializeSearchResponse } from "utils/deserializeSearchResponse";
 
@@ -145,21 +145,19 @@ export const useChat = ({
   const onStreamUpdate = (update: StreamUpdate) => {
     const { references, details, updatedText, isDone } = update;
 
-    const factualConsistencyScore = extractFactualConsistencyScore(update);
+    const factualConsistencyScore = details?.factualConsistency?.score;
 
     if (updatedText) {
       setIsStreamingResponse(true);
       setIsLoading(false);
     }
 
-    const chatDetail = details?.find((detail) => detail.type === "chat") as ChatDetail | undefined;
-
-    if (chatDetail) {
-      setConversationId(chatDetail.data.conversationId ?? null);
+    if (details?.chat) {
+      setConversationId(details.chat.conversationId ?? null);
     }
 
     setActiveMessage((prev) => ({
-      id: chatDetail ? chatDetail.data.turnId : "",
+      id: details?.chat?.turnId ?? "",
       question: recentQuestion.current,
       answer: updatedText ?? "",
       results: [...(prev?.results ?? []), ...(references ?? [])],
@@ -194,15 +192,4 @@ export const useChat = ({
     startNewConversation,
     hasError
   };
-};
-
-const extractFactualConsistencyScore = (update: StreamUpdate) => {
-  const { details } = update;
-  const factualConsistencyDetail = details?.find((detail) => detail.type === "factualConsistency") as
-    | FactualConsistencyDetail
-    | undefined;
-
-  if (factualConsistencyDetail) {
-    return factualConsistencyDetail.data.score;
-  }
 };

--- a/src/utils/sendSearchRequest.ts
+++ b/src/utils/sendSearchRequest.ts
@@ -1,6 +1,10 @@
 import { SummaryLanguage } from "../types";
 
 type Config = {
+  customerId: string;
+  corpusId: string;
+  endpoint: string;
+  apiKey: string;
   filter: string;
   queryValue?: string;
   language?: SummaryLanguage;
@@ -15,10 +19,7 @@ type Config = {
   summaryNumResults?: number;
   summaryNumSentences?: number;
   summaryPromptName?: string;
-  customerId: string;
-  corpusId: string;
-  endpoint: string;
-  apiKey: string;
+  enableFactualConsistencyScore?: boolean;
   chat?: {
     conversationId?: string;
   };
@@ -28,6 +29,10 @@ type Config = {
  * Send a request to the query API.
  */
 export const sendSearchRequest = async ({
+  customerId,
+  corpusId,
+  endpoint,
+  apiKey,
   filter,
   queryValue,
   language,
@@ -42,10 +47,7 @@ export const sendSearchRequest = async ({
   summaryNumResults,
   summaryNumSentences,
   summaryPromptName,
-  customerId,
-  corpusId,
-  endpoint,
-  apiKey,
+  enableFactualConsistencyScore,
   chat
 }: Config) => {
   const lambda =
@@ -80,6 +82,7 @@ export const sendSearchRequest = async ({
           ? {
               summary: [
                 {
+                  factualConsistencyScore: enableFactualConsistencyScore,
                   responseLang: language,
                   maxSummarizedResults: summaryNumResults,
                   summarizerPromptName: summaryPromptName,

--- a/src/vui/components/_index.scss
+++ b/src/vui/components/_index.scss
@@ -1,8 +1,10 @@
 @import "../styleUtils/index";
 @import "accordion/index";
+@import "badge/index";
 @import "button/index";
 @import "flex/index";
 @import "grid/index";
+@import "link/index";
 @import "searchInput/index";
 @import "spinner/index";
 @import "spacer/index";

--- a/src/vui/components/badge/Badge.tsx
+++ b/src/vui/components/badge/Badge.tsx
@@ -1,0 +1,50 @@
+import { MouseEvent } from "react";
+import classNames from "classnames";
+import { getTrackingProps } from "../../utils/getTrackingProps";
+import { useVuiContext } from "../context/Context";
+import { LinkProps } from "../link/types";
+
+export const BADGE_COLOR = ["accent", "primary", "danger", "warning", "success", "neutral"] as const;
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+  color: (typeof BADGE_COLOR)[number];
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  href?: LinkProps["href"];
+  target?: LinkProps["target"];
+  track?: LinkProps["track"];
+};
+
+export const VuiBadge = ({ children, className, color, onClick, href, target, track, ...rest }: Props) => {
+  const { createLink } = useVuiContext();
+
+  const classes = classNames(className, "vuiBadge", `vuiBadge--${color}`, {
+    "vuiBadge--clickable": onClick ?? href
+  });
+
+  if (onClick) {
+    return (
+      <button className={classes} onClick={onClick} {...rest}>
+        {children}
+      </button>
+    );
+  }
+
+  if (href) {
+    return createLink({
+      className: classes,
+      href,
+      onClick,
+      children,
+      target,
+      ...getTrackingProps(track)
+    });
+  }
+
+  return (
+    <div className={classes} {...rest}>
+      {children}
+    </div>
+  );
+};

--- a/src/vui/components/badge/_index.scss
+++ b/src/vui/components/badge/_index.scss
@@ -1,0 +1,64 @@
+@use "sass:map";
+
+.vuiBadge {
+  display: inline-block;
+  font-size: $fontSizeSmall;
+  line-height: 1;
+  padding: $sizeXxs $sizeXs;
+  border-radius: $sizeS;
+  font-family: inherit;
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+.vuiBadge--clickable {
+  cursor: pointer;
+}
+
+// Color
+$color: (
+  accent: (
+    "color": $colorAccent,
+    "background-color": transparentize($colorAccent, 0.9),
+    "border-color": transparentize($colorAccent, 0.9)
+  ),
+  primary: (
+    "color": $colorPrimary,
+    "background-color": transparentize($colorPrimary, 0.9),
+    "border-color": transparentize($colorPrimary, 0.9)
+  ),
+  success: (
+    "color": $colorSuccess,
+    "background-color": transparentize($colorSuccess, 0.9),
+    "border-color": transparentize($colorSuccess, 0.9)
+  ),
+  warning: (
+    "color": $colorWarning,
+    "background-color": transparentize($colorWarning, 0.9),
+    "border-color": transparentize($colorWarning, 0.9)
+  ),
+  danger: (
+    "color": $colorDanger,
+    "background-color": transparentize($colorDanger, 0.9),
+    "border-color": transparentize($colorDanger, 0.9)
+  ),
+  neutral: (
+    "color": $colorText,
+    "background-color": $colorLightShade,
+    "border-color": transparentize($colorText, 0.9)
+  )
+);
+
+@each $colorName, $colorValue in $color {
+  .vuiBadge--#{$colorName} {
+    color: #{map.get($colorValue, "color")} !important;
+    background-color: #{map.get($colorValue, "background-color")};
+    border: 1px solid #{map.get($colorValue, "border-color")};
+    transition: all $transitionSpeed;
+
+    &.vuiBadge--clickable:hover {
+      border-color: #{map.get($colorValue, "color")};
+      text-decoration: none;
+    }
+  }
+}

--- a/src/vui/components/index.ts
+++ b/src/vui/components/index.ts
@@ -1,4 +1,5 @@
 import { VuiAccordion } from "./accordion/Accordion";
+import { VuiBadge } from "./badge/Badge";
 import { VuiButtonPrimary } from "./button/ButtonPrimary";
 import { VuiButtonSecondary } from "./button/ButtonSecondary";
 import { VuiContextProvider } from "./context/Context";
@@ -20,6 +21,7 @@ export {
   TEXT_SIZE,
   TITLE_SIZE,
   VuiAccordion,
+  VuiBadge,
   VuiButtonPrimary,
   VuiButtonSecondary,
   VuiContextProvider,


### PR DESCRIPTION
Changes:
* Upgrades to `stream-query-client@v2.0.2`
* Adds `summaryPromptName` and `enableFactualConsistencyScore` props.
* Introduces breaking change in which `useChat` now expects a configuration object instead of an arguments list (breaking change that bumps the major to 3.0.0).
* Refactors tests to mock `sendSearchRequest` and `streamQuery` more explicitly and clean up after each test to avoid side effects.
* Other minor refactors.

## Screenshots

![image](https://github.com/vectara/react-chatbot/assets/1238659/b934d26b-833a-475f-a9ac-af3017a34570)
