### PR TITLE
Add exampleQuestions prop. Adjust default empty state design. Refactor tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,13 @@ Configure the title in the header of the chatbot window.
 
 Configure the placeholder text in the chatbot's input.
 
+##### `exampleQuestions` (optional)
+
+Configure the example questions that will be suggested to the user when there are no messages to display.
+
 ##### `emptyStateDisplay` (optional)
 
-Configure JSX content to render in the messages window when there are no messages to display.
+Configure JSX content to render in the messages window when there are no messages to display. When configured, this will supersede `exampleQuestions`.
 
 ##### `isInitiallyOpen` (optional)
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@vectara/react-chatbot",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^17.0.0",

--- a/docs/src/components/ConfigurationDrawer.tsx
+++ b/docs/src/components/ConfigurationDrawer.tsx
@@ -39,6 +39,8 @@ type Props = {
   onUpdateIsStreamingEnabled: (isStreamingEnabled: boolean) => void;
   language: SummaryLanguage;
   onUpdateLanguage: (language: SummaryLanguage) => void;
+  exampleQuestions: string;
+  onUpdateExampleQuestions: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 export const ConfigurationDrawer = ({
@@ -61,7 +63,9 @@ export const ConfigurationDrawer = ({
   isStreamingEnabled,
   onUpdateIsStreamingEnabled,
   language,
-  onUpdateLanguage
+  onUpdateLanguage,
+  exampleQuestions,
+  onUpdateExampleQuestions
 }: Props) => {
   return (
     <VuiDrawer
@@ -126,6 +130,12 @@ export const ConfigurationDrawer = ({
 
       <VuiSpacer size="m" />
 
+      <VuiFormGroup label="Example questions" labelFor="exampleQuestions">
+        <VuiTextInput value={exampleQuestions} onChange={onUpdateExampleQuestions} fullWidth />
+      </VuiFormGroup>
+
+      <VuiSpacer size="m" />
+
       <VuiLabel>Enable Streaming</VuiLabel>
 
       <VuiSpacer size="xs" />
@@ -143,7 +153,7 @@ export const ConfigurationDrawer = ({
         <VuiSelect
           value={language}
           onChange={(evt) => {
-            onUpdateLanguage(evt.target.value);
+            onUpdateLanguage(evt.target.value as SummaryLanguage);
           }}
           options={SUMMARY_LANGUAGES.filter((lang) => lang !== "auto").map((lang) => ({
             text: lang,

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -40,7 +40,8 @@ const generateCodeSnippet = (
   inputSize?: string,
   emptyStateDisplay?: string,
   isStreamingEnabled?: boolean,
-  language?: SummaryLanguage
+  language?: SummaryLanguage,
+  exampleQuestions?: string
 ) => {
   const props = [
     `customerId="${customerId === "" ? "<Your Vectara customer ID>" : customerId}"`,
@@ -56,6 +57,15 @@ const generateCodeSnippet = (
 
   if (placeholder) {
     props.push(`placeholder=${formatStringProp(placeholder)}`);
+  }
+
+  if (exampleQuestions) {
+    props.push(
+      `exampleQuestions={[${exampleQuestions
+        .split(",")
+        .map((value) => formatStringProp(value.trim()))
+        .join(", ")}]}`
+    );
   }
 
   if (inputSize) {
@@ -102,6 +112,7 @@ const App = () => {
   const [isStreamingEnabled, setIsStreamingEnabled] = useState<boolean>(true);
   const [language, setLanguage] = useState<SummaryLanguage>("eng");
   const [emptyStateJsx, setEmptyStateJsx] = useState<string>("");
+  const [exampleQuestions, setExampleQuestions] = useState<string>("What is Vectara?, How does RAG work?");
 
   const onUpdateCorpusIds = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const sanitizedValue = e.target.value.trim();
@@ -133,12 +144,18 @@ const App = () => {
     setEmptyStateJsx(e.target.value);
   }, []);
 
+  const onUpdateExampleQuestions = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setExampleQuestions(e.target.value);
+  }, []);
+
   const CustomEmptyStateDisplay = useCallback(() => {
     return (
       // @ts-ignore
       <JsxParser jsx={emptyStateJsx} />
     );
   }, [emptyStateJsx]);
+
+  const parsedExampleQuestions = exampleQuestions && exampleQuestions.split(",");
 
   return (
     <>
@@ -196,6 +213,7 @@ const App = () => {
               title={title === "" ? undefined : title}
               placeholder={placeholder}
               inputSize={inputSize}
+              exampleQuestions={parsedExampleQuestions}
               emptyStateDisplay={emptyStateJsx === "" ? undefined : <CustomEmptyStateDisplay />}
               isInitiallyOpen={isChatbotForcedOpen}
               zIndex={9}
@@ -238,7 +256,8 @@ const App = () => {
                 inputSize,
                 emptyStateJsx,
                 isStreamingEnabled,
-                language
+                language,
+                exampleQuestions
               )}
             </VuiCode>
             <VuiSpacer size="xxl" />
@@ -327,6 +346,8 @@ export const App = () => {
               onUpdateIsStreamingEnabled={setIsStreamingEnabled}
               language={language}
               onUpdateLanguage={setLanguage}
+              exampleQuestions={exampleQuestions}
+              onUpdateExampleQuestions={onUpdateExampleQuestions}
             />
           </div>
         </VuiAppContent>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/react-chatbot",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/react-chatbot",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^17.0.0",

--- a/src/components/chatView.scss
+++ b/src/components/chatView.scss
@@ -171,10 +171,7 @@ $chatbotPosition: $sizeS;
 }
 
 .vrcbEmptyMessages {
-  color: $colorFullShade;
-  font-weight: $fontWeightBold;
   height: 100%;
-  opacity: 0.3;
 }
 
 .vrcbRetryButton {

--- a/src/components/exampleQuestions/DefaultEmptyPrompt.tsx
+++ b/src/components/exampleQuestions/DefaultEmptyPrompt.tsx
@@ -1,0 +1,20 @@
+import { VuiFlexContainer, VuiText, VuiTextColor } from "vui";
+import { ChatBubbleIcon } from "../Icons";
+
+export const DefaultEmptyPrompt = () => (
+  <VuiFlexContainer
+    className="vrcbEmptyMessages"
+    spacing="none"
+    alignItems="center"
+    justifyContent="center"
+    direction="column"
+  >
+    <ChatBubbleIcon size="80px" color="#cbcdde" />
+
+    <VuiText>
+      <p>
+        <VuiTextColor color="subdued">Ask anything.</VuiTextColor>
+      </p>
+    </VuiText>
+  </VuiFlexContainer>
+);

--- a/src/components/exampleQuestions/ExampleQuestion.tsx
+++ b/src/components/exampleQuestions/ExampleQuestion.tsx
@@ -1,0 +1,33 @@
+import { VuiSpacer, VuiTextColor, VuiTitle, VuiTopicButton } from "../../vui";
+
+type Props = {
+  children?: React.ReactNode;
+  onClick: () => void;
+  title?: string;
+};
+
+export const ExampleQuestion = ({ children, onClick, title }: Props) => {
+  const content = (
+    <>
+      {title && (
+        <>
+          <VuiTitle size="s">
+            <p>
+              <VuiTextColor color="primary">{title}</VuiTextColor>
+            </p>
+          </VuiTitle>
+
+          {children && <VuiSpacer size="xxs" />}
+        </>
+      )}
+
+      {children}
+    </>
+  );
+
+  return (
+    <VuiTopicButton onClick={onClick} data-testid="exampleQuestion">
+      {content}
+    </VuiTopicButton>
+  );
+};

--- a/src/components/exampleQuestions/ExampleQuestions.tsx
+++ b/src/components/exampleQuestions/ExampleQuestions.tsx
@@ -1,0 +1,35 @@
+import { VuiGrid, VuiSpacer, VuiText, VuiTextColor } from "../../vui";
+import { ExampleQuestion } from "./ExampleQuestion";
+import { DefaultEmptyPrompt } from "./DefaultEmptyPrompt";
+
+type Props = {
+  exampleQuestions: string[];
+  onSubmitChat: (query: string) => void;
+};
+
+export const ExampleQuestions = ({ exampleQuestions, onSubmitChat }: Props) => {
+  const hasExampleQuestions = exampleQuestions.length > 0;
+  if (!hasExampleQuestions) return <DefaultEmptyPrompt />;
+
+  return (
+    <div className="vrcbExampleQuestionsContainer">
+      <VuiText>
+        <p>
+          <VuiTextColor color="subdued">Try out these example questions</VuiTextColor>
+        </p>
+      </VuiText>
+
+      <VuiSpacer size="m" />
+
+      <VuiGrid columns={3}>
+        {exampleQuestions.map((exampleQuestion) => (
+          <ExampleQuestion
+            key={exampleQuestion}
+            onClick={() => onSubmitChat(exampleQuestion)}
+            title={exampleQuestion}
+          />
+        ))}
+      </VuiGrid>
+    </div>
+  );
+};

--- a/src/components/exampleQuestions/exampleQuestions.scss
+++ b/src/components/exampleQuestions/exampleQuestions.scss
@@ -1,0 +1,9 @@
+@import "../../vui/styleUtils/index.scss";
+
+.vrcbExampleQuestionsContainer {
+  padding: $sizeM;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -6,4 +6,5 @@
 
 @import "./components/chatView.scss";
 @import "./components/loader.scss";
+@import "./components/exampleQuestions/exampleQuestions.scss";
 @import "./vui/_index.scss";

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 import { screen } from "shadow-dom-testing-library";
 import { ReactChatbot } from "./";
-import { useChat } from "./useChat";
+import * as useChatInterface from "./useChat";
 
 const MIN_PROPS = {
   customerId: "mock-customer-id",
@@ -49,25 +49,36 @@ window.CSSStyleSheet = jest.fn().mockImplementation(() => ({
   replaceSync: () => {}
 }));
 
-const mockSendMessage = jest.fn();
-
-jest.mock("./useChat", () => ({
-  useChat: jest.fn()
-}));
-
 describe("ReactChatbot", () => {
-  (useChat as jest.Mock).mockImplementation(() => ({
-    sendMessage: mockSendMessage,
-    messageHistory: []
-  }));
+  let mockSendMessage: jest.Mock;
+  let useChatSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockSendMessage = jest.fn();
+    useChatSpy = jest.spyOn(useChatInterface, "useChat");
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
   it("should render in closed state by default", () => {
+    useChatSpy.mockImplementation(() => ({
+      sendMessage: mockSendMessage,
+      messageHistory: []
+    }));
+
     render(<ReactChatbot {...MIN_PROPS} />);
 
     expect(screen.getByShadowText("My Chatbot")).toBeInTheDocument();
   });
 
   it("should optionally render in open state", () => {
+    useChatSpy.mockImplementation(() => ({
+      sendMessage: mockSendMessage,
+      messageHistory: []
+    }));
+
     render(<ReactChatbot {...MIN_PROPS} isInitiallyOpen={true} />);
 
     expect(screen.getByShadowText("Ask anything.")).toBeInTheDocument();
@@ -75,6 +86,11 @@ describe("ReactChatbot", () => {
   });
 
   it("should render based on optional parameters", () => {
+    useChatSpy.mockImplementation(() => ({
+      sendMessage: mockSendMessage,
+      messageHistory: []
+    }));
+
     render(<ReactChatbot {...MIN_PROPS} {...OPTIONAL_PROPS} />);
     const openButton = screen.getByShadowText(OPTIONAL_PROPS.title);
 
@@ -88,7 +104,7 @@ describe("ReactChatbot", () => {
   });
 
   it("should render messages", () => {
-    (useChat as jest.Mock).mockImplementation(() => ({
+    useChatSpy.mockImplementation(() => ({
       sendMessage: mockSendMessage,
       messageHistory: MOCK_MESSAGE_HISTORY
     }));
@@ -101,6 +117,11 @@ describe("ReactChatbot", () => {
   });
 
   it("should execute callback when sending message", () => {
+    useChatSpy.mockImplementation(() => ({
+      sendMessage: mockSendMessage,
+      messageHistory: []
+    }));
+
     render(<ReactChatbot {...MIN_PROPS} isInitiallyOpen={true} />);
     const sendButton = screen.getByShadowText("Send");
     const input = screen.getByShadowTestId("queryInput");
@@ -116,5 +137,19 @@ describe("ReactChatbot", () => {
 
     expect(mockSendMessage).toHaveBeenCalledTimes(2);
     expect((input as HTMLInputElement).value).toEqual("");
+  });
+
+  it("renders example questions", () => {
+    useChatSpy.mockImplementation(() => ({
+      sendMessage: mockSendMessage,
+      messageHistory: []
+    }));
+
+    render(<ReactChatbot {...MIN_PROPS} exampleQuestions={["What is RAG"]} isInitiallyOpen={true} />);
+    const exampleQuestion = screen.getByShadowTestId("exampleQuestion");
+    expect(exampleQuestion.textContent).toEqual("What is RAG");
+
+    fireEvent.click(exampleQuestion);
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,9 @@ export interface Props {
   // Text to be shown when the input field has no text
   placeholder?: string;
 
+  // Example questions to prompt the user
+  exampleQuestions?: string[];
+
   // Size of input. Defaults to "large".
   inputSize?: "large" | "medium";
 
@@ -50,6 +53,7 @@ const ReactChatbotInternal: FC<Props> = ({
   corpusIds,
   title,
   placeholder,
+  exampleQuestions,
   inputSize,
   emptyStateDisplay,
   isInitiallyOpen,
@@ -65,6 +69,7 @@ const ReactChatbotInternal: FC<Props> = ({
         apiKey={apiKey}
         title={title}
         placeholder={placeholder}
+        exampleQuestions={exampleQuestions}
         inputSize={inputSize}
         emptyStateDisplay={emptyStateDisplay}
         isInitiallyOpen={isInitiallyOpen}
@@ -98,6 +103,7 @@ class ReactChatbotWebComponent extends HTMLElement {
       "apikey",
       "title",
       "placeholder",
+      "examplequestions",
       "inputsize",
       "isinitiallyopen",
       "zindex",
@@ -142,6 +148,8 @@ class ReactChatbotWebComponent extends HTMLElement {
     const apiKey = this.getAttribute("apiKey") ?? "";
     const title = this.getAttribute("title") ?? undefined;
     const placeholder = this.getAttribute("placeholder") ?? undefined;
+    const rawExampleQuestions = this.getAttribute("exampleQuestions");
+    const exampleQuestions = rawExampleQuestions ? rawExampleQuestions.split(",") : undefined;
     const inputSize = this.getAttribute("inputSize") ?? undefined;
     const isInitiallyOpen = this.getAttribute("isInitiallyOpen") === "true";
     const emptyStateDisplay = this.emptyStateDisplay ?? undefined;
@@ -158,6 +166,7 @@ class ReactChatbotWebComponent extends HTMLElement {
           apiKey={apiKey}
           title={title}
           placeholder={placeholder}
+          exampleQuestions={exampleQuestions}
           inputSize={inputSize as "large" | "medium" | undefined}
           emptyStateDisplay={emptyStateDisplay}
           isInitiallyOpen={isInitiallyOpen}

--- a/src/vui/components/_index.scss
+++ b/src/vui/components/_index.scss
@@ -2,7 +2,9 @@
 @import "accordion/index";
 @import "button/index";
 @import "flex/index";
+@import "grid/index";
 @import "searchInput/index";
 @import "spinner/index";
 @import "spacer/index";
+@import "topicButton/index";
 @import "typography/index";

--- a/src/vui/components/context/Context.test.util.tsx
+++ b/src/vui/components/context/Context.test.util.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+import { Link } from "react-router-dom";
+import { LinkProps } from "../link/types";
+import { VuiContextProvider } from "./Context";
+
+const linkProvider = (linkConfig: LinkProps) => {
+  const { className, href, onClick, children, ...rest } = linkConfig;
+
+  return (
+    <Link className={className} to={href ?? ""} onClick={onClick} {...rest}>
+      {children}
+    </Link>
+  );
+};
+
+export const renderWithContext = (children: React.ReactNode, ...rest: any): ReturnType<typeof render> => {
+  return render(<VuiContextProvider linkProvider={linkProvider}>{children}</VuiContextProvider>, ...rest);
+};

--- a/src/vui/components/context/Context.tsx
+++ b/src/vui/components/context/Context.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, ReactNode } from "react";
+import { LinkProps } from "../link/types";
+
+type LinkProvider = (linkConfig: LinkProps) => JSX.Element;
+type PathProvider = () => string;
+
+interface VuiContextType {
+  createLink: LinkProvider;
+  getPath: PathProvider;
+  DrawerTitle: keyof JSX.IntrinsicElements;
+}
+
+const VuiContext = createContext<VuiContextType | undefined>(undefined);
+
+type Props = {
+  children: ReactNode;
+  linkProvider?: LinkProvider;
+  pathProvider?: PathProvider;
+  drawerTitle?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+};
+
+export const VuiContextProvider = ({ children, linkProvider, pathProvider, drawerTitle = "h2" }: Props) => {
+  const createLink = (linkConfig: LinkProps) => {
+    if (linkProvider) return linkProvider(linkConfig);
+
+    const { className, href, onClick, children, ...rest } = linkConfig;
+
+    return (
+      <a className={className} href={href} onClick={onClick} {...rest}>
+        {children}
+      </a>
+    );
+  };
+
+  const getPath = () => {
+    return pathProvider ? pathProvider() : window.location.pathname;
+  };
+
+  const DrawerTitle = drawerTitle as keyof JSX.IntrinsicElements;
+
+  return <VuiContext.Provider value={{ createLink, getPath, DrawerTitle }}>{children}</VuiContext.Provider>;
+};
+
+export const useVuiContext = () => {
+  const context = useContext(VuiContext);
+  if (context === undefined) {
+    throw new Error("useVuiContext must be used within a VuiContextProvider");
+  }
+  return context;
+};

--- a/src/vui/components/grid/Grid.tsx
+++ b/src/vui/components/grid/Grid.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import classNames from "classnames";
+import { FlexSpacing } from "../flex/types";
+
+export const COLUMNS = [1, 2, 3] as const;
+export type Columns = (typeof COLUMNS)[number];
+
+type Props = {
+  children?: React.ReactNode;
+  columns?: Columns;
+  spacing?: FlexSpacing;
+  className?: string;
+};
+
+export const VuiGrid = ({ children, columns = 2, spacing = "m", className, ...rest }: Props) => {
+  const classes = classNames("vuiGridContainer", className);
+  const contentClasses = classNames("vuiGrid", `vuiGrid--${spacing}`, `vuiGrid--columns${columns}`);
+
+  return (
+    <div className={classes} {...rest}>
+      <div className={contentClasses}>{children}</div>
+    </div>
+  );
+};

--- a/src/vui/components/grid/_index.scss
+++ b/src/vui/components/grid/_index.scss
@@ -1,0 +1,51 @@
+.vuiGridContainer {
+  container-type: inline-size;
+  width: 100%;
+}
+
+.vuiGrid {
+  display: grid;
+}
+
+// spacing
+$spacing: (
+  xss: $sizeXxs,
+  xs: $sizeXs,
+  s: $sizeS,
+  m: $sizeM,
+  l: $sizeL,
+  xl: $sizeXl,
+  xxl: $sizeXxl
+);
+
+@each $spacingName, $spacingValue in $spacing {
+  .vuiGrid--#{$spacingName} {
+    column-gap: $spacingValue;
+    row-gap: $spacingValue;
+  }
+}
+
+.vuiGrid--columns1 {
+  grid-template-columns: 1fr;
+}
+
+.vuiGrid--columns2 {
+  grid-template-columns: 1fr 1fr;
+}
+
+.vuiGrid--columns3 {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+@container (width < 800px) {
+  .vuiGrid--columns3 {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@container (width < 500px) {
+  .vuiGrid--columns2,
+  .vuiGrid--columns3 {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/vui/components/index.ts
+++ b/src/vui/components/index.ts
@@ -1,8 +1,11 @@
 import { VuiAccordion } from "./accordion/Accordion";
 import { VuiButtonPrimary } from "./button/ButtonPrimary";
 import { VuiButtonSecondary } from "./button/ButtonSecondary";
+import { VuiContextProvider } from "./context/Context";
 import { VuiFlexContainer } from "./flex/FlexContainer";
 import { VuiFlexItem } from "./flex/FlexItem";
+import { VuiGrid } from "./grid/Grid";
+import { VuiLink } from "./link/Link";
 import { VuiSearchInput } from "./searchInput/SearchInput";
 import { VuiSpacer } from "./spacer/Spacer";
 import { VuiSpinner } from "./spinner/Spinner";
@@ -10,6 +13,7 @@ import { VuiText } from "./typography/Text";
 import { VuiTextColor } from "./typography/TextColor";
 import { TEXT_COLOR, TEXT_SIZE, TITLE_SIZE } from "./typography/types";
 import { VuiTitle } from "./typography/Title";
+import { VuiTopicButton } from "./topicButton/TopicButton";
 
 export {
   TEXT_COLOR,
@@ -18,12 +22,16 @@ export {
   VuiAccordion,
   VuiButtonPrimary,
   VuiButtonSecondary,
+  VuiContextProvider,
   VuiFlexContainer,
   VuiFlexItem,
+  VuiGrid,
+  VuiLink,
   VuiSearchInput,
   VuiSpacer,
   VuiSpinner,
   VuiText,
   VuiTextColor,
-  VuiTitle
+  VuiTitle,
+  VuiTopicButton
 };

--- a/src/vui/components/link/Link.test.tsx
+++ b/src/vui/components/link/Link.test.tsx
@@ -1,0 +1,51 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import "@testing-library/jest-dom";
+import { VuiLink } from "./Link";
+import { VuiContextProvider } from "../context/Context";
+import { LinkProps } from "./types";
+import { renderWithContext } from "../context/Context.test.util";
+
+describe("VuiLink", () => {
+  describe("track", () => {
+    it("allows referrer information when true", () => {
+      const { asFragment } = renderWithContext(
+        <VuiLink href="https://www.vectara.com" track>
+          Link
+        </VuiLink>,
+        { wrapper: MemoryRouter }
+      );
+
+      expect(asFragment()).toMatchInlineSnapshot(`
+        <DocumentFragment>
+          <a
+            class="vuiLink"
+            href="https://www.vectara.com"
+            referrerpolicy="no-referrer-when-downgrade"
+            rel="noopener"
+          >
+            Link
+          </a>
+        </DocumentFragment>
+      `);
+    });
+
+    it("disallows referrer information when false (default)", () => {
+      const { asFragment } = renderWithContext(<VuiLink href="https://www.vectara.com">Link</VuiLink>, {
+        wrapper: MemoryRouter
+      });
+
+      expect(asFragment()).toMatchInlineSnapshot(`
+        <DocumentFragment>
+          <a
+            class="vuiLink"
+            href="https://www.vectara.com"
+            rel="noopener"
+          >
+            Link
+          </a>
+        </DocumentFragment>
+      `);
+    });
+  });
+});

--- a/src/vui/components/link/Link.tsx
+++ b/src/vui/components/link/Link.tsx
@@ -1,0 +1,49 @@
+import classNames from "classnames";
+import { getTrackingProps } from "../../utils/getTrackingProps";
+import { useVuiContext } from "../context/Context";
+import { LinkProps } from "./types";
+
+export const VuiLinkInternal = ({ ...rest }: LinkProps) => {
+  return <VuiLink {...rest} track />;
+};
+
+export const VuiLink = ({ children, href, target, onClick, className, track, isAnchor, ...rest }: LinkProps) => {
+  const { createLink } = useVuiContext();
+
+  if (!href) {
+    return (
+      <button className={classNames("vuiLink", "vuiLink--button", className)} onClick={onClick} {...rest}>
+        {children}
+      </button>
+    );
+  }
+
+  const props: {
+    target?: LinkProps["target"];
+    rel?: string;
+    referrerpolicy?: string;
+    title?: string;
+    id?: string;
+    role?: string;
+  } = { ...rest, ...getTrackingProps(track) };
+
+  if (target === "_blank") {
+    props.target = target;
+  }
+
+  if (isAnchor) {
+    return (
+      <a className={classNames("vuiLink", className)} href={href} onClick={onClick} {...props}>
+        {children}
+      </a>
+    );
+  }
+
+  return createLink({
+    className: classNames("vuiLink", className),
+    href,
+    onClick,
+    children,
+    ...props
+  });
+};

--- a/src/vui/components/link/_index.scss
+++ b/src/vui/components/link/_index.scss
@@ -1,0 +1,17 @@
+.vuiLink {
+  color: $colorPrimary !important;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+
+    // This is needed when wrapping an element that has display: inline-flex.
+    & * {
+      text-decoration: underline;
+    }
+  }
+}
+
+.vuiLink--button {
+  display: inline;
+}

--- a/src/vui/components/link/types.ts
+++ b/src/vui/components/link/types.ts
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+
+export type LinkProps = {
+  children: ReactNode;
+  href?: string;
+  className?: string;
+  target?: "_blank";
+  onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
+  track?: boolean;
+  // ...rest
+  title?: string;
+  id?: string;
+  role?: string;
+  isAnchor?: boolean;
+  tabIndex?: number;
+  "data-testid"?: string;
+};

--- a/src/vui/components/topicButton/TopicButton.tsx
+++ b/src/vui/components/topicButton/TopicButton.tsx
@@ -1,0 +1,56 @@
+import classNames from "classnames";
+import { VuiSpacer } from "../spacer/Spacer";
+import { VuiTextColor } from "../typography/TextColor";
+import { VuiTitle } from "../typography/Title";
+import { useVuiContext } from "../context/Context";
+
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  href?: string;
+  onClick?: () => void;
+  title?: string;
+  fullWidth?: boolean;
+};
+
+export const VuiTopicButton = ({ children, className, href, onClick, title, fullWidth, ...rest }: Props) => {
+  const { createLink } = useVuiContext();
+
+  const classes = classNames("vuiTopicButton", className, {
+    "vuiTopicButton--fullWidth": fullWidth
+  });
+
+  const content = (
+    <>
+      {title && (
+        <>
+          <VuiTitle size="s">
+            <p>
+              <VuiTextColor color="primary">{title}</VuiTextColor>
+            </p>
+          </VuiTitle>
+
+          {children && <VuiSpacer size="xxs" />}
+        </>
+      )}
+
+      {children}
+    </>
+  );
+
+  if (href) {
+    return createLink({
+      className: classes,
+      href,
+      onClick,
+      children: content,
+      ...rest
+    });
+  }
+
+  return (
+    <button className={classes} onClick={onClick} {...rest}>
+      {content}
+    </button>
+  );
+};

--- a/src/vui/components/topicButton/_index.scss
+++ b/src/vui/components/topicButton/_index.scss
@@ -1,0 +1,21 @@
+.vuiTopicButton {
+  display: inline-block;
+  text-decoration: none;
+  background-color: $colorEmptyShade;
+  border-radius: $sizeXs;
+  box-shadow: $shadowLargeStart;
+  transition: box-shadow $transitionSpeed, border-color $transitionSpeed;
+  overflow: hidden;
+  padding: $sizeM $sizeL;
+  text-align: left;
+
+  &:hover {
+    text-decoration: none;
+    box-shadow: $shadowLargeEnd, $colorPrimary 0 0 1px 1px;
+    z-index: 1;
+  }
+}
+
+.vuiTopicButton--fullWidth {
+  width: 100%;
+}


### PR DESCRIPTION
Fixes https://github.com/vectara/react-chatbot/issues/5

## Changes

* Adds `exampleQuestions` prop, including docs and tests.
* Adjusts the design of the default empty state for consistency with design language.
* Refactors tests to mock useChat more explicitly and clean up after each test to avoid side effects.
* Adds VuiContextProvider, VuiGrid, VuiLink, and VuiTopicButton.

## Screenshots

![image](https://github.com/vectara/react-chatbot/assets/1238659/67d797b9-8ae9-4507-be30-689170d1a8a6)

![image](https://github.com/vectara/react-chatbot/assets/1238659/496899c6-2ecb-41ff-a709-bea247143d43)
