### PR TITLE
Remove old cross-attentional reranker

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -165,7 +165,7 @@ export type ChatQueryResponse = {
   rephrased_query: string
 }
 
-export type RerankerId = 272725717 | 272725719 | 272725718
+export type RerankerId = 272725719 | 272725718
 export const mmrRerankerId = 272725718;
 export const DEFAULT_DOMAIN = "https://api.vectara.io";
 


### PR DESCRIPTION
This hasn't been used for a while and has been replaced with the multilingual x-attn reranker (aka Slingshot)